### PR TITLE
Remove padding characters from cert URL.

### DIFF
--- a/util.go
+++ b/util.go
@@ -29,5 +29,5 @@ const CertURLPrefix = "amppkg/cert"
 // format changes to need escaping in the future.
 func CertName(cert *x509.Certificate) string {
 	sum := sha256.Sum256(cert.Raw)
-	return base64.URLEncoding.EncodeToString(sum[:])
+	return base64.RawURLEncoding.EncodeToString(sum[:])
 }


### PR DESCRIPTION
This makes the URL prettier by removing reserved characters, and matches
the behavior of the planned AMP CDN URL.