### PR TITLE
Update impl snapshot URLS to the latest location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # AMP Packager
 
-> **WARNING**: This code is still brand new, and highly experimental. Feel free
-> to play around with it, but be cautious. Examine the code.
+> **WARNING**: This code is still brand new, and highly experimental. The
+> specification is still changing, and this is an implementation of a snapshot
+> of it, as a proof of concept. Feel free to play around with it, but be
+> cautious. Examine the code.
 
 The AMP Packager creates "AMP Packages" (implemented as [Signed HTTP
-Exchanges](https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html))
+Exchanges](https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00))
 containing AMP documents. These packages are consumed by the [Google AMP
-Cache](https://www.ampproject.org/docs/fundamentals/how_cached), cached, and
-when available, linked to from Google Search instead of normal AMP page. The
-packages are signed with a certificate, which means that Chrome users will see
-that certificate's domain in the URL bar instead of `google.com` or
-`ampproject.org`.
+Cache](https://www.ampproject.org/docs/fundamentals/how_cached) and cached.
+Eventually, a future variant of these packages will be linked to from Google
+Search instead of normal AMP page. The packages are signed with a certificate,
+which means that Chrome users will see that certificate's domain in the URL bar
+instead of `google.com` or `ampproject.org`, and that the web page will run on
+that origin.
 
 These packages have a maximum lifetime of 7 days, which minimizes the risk of
 another cache serving a stale copy of this signed content. In the future, the
 [AMP update-cache API](https://developers.google.com/amp/cache/update-cache)
 will support updating AMP Packages, though it doesn't yet.
 
-The packager is an HTTP server that sits behind your frontend server; it
-fetches and signs AMP documents as requested by the AMP Cache.
+The packager is an HTTP server that sits behind a frontend server; it fetches
+and signs AMP documents as requested by the AMP Cache.
 
 ## How to use
 

--- a/certcache.go
+++ b/certcache.go
@@ -47,7 +47,7 @@ func NewCertCache(cert *x509.Certificate, pemContent []byte) (*CertCache, error)
 func (this CertCache) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	println("path", req.URL.Path)
 	if req.URL.Path == path.Join("/", CertURLPrefix, url.PathEscape(this.certName)) {
-		// https://jyasskin.github.io/webpackage/implementation-draft/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#cert-chain-format
+		// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-3.3
 		resp.Header().Set("Content-Type", "application/octet-stream")
 		resp.Header().Set("ETag", "\""+this.certName+"\"")
 		// TODO(twifkak): Add cache headers.

--- a/packager.go
+++ b/packager.go
@@ -44,7 +44,7 @@ const userAgent = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) " +
 	"Safari/537.36 (compatible; amppackager/0.0.0; +https://github.com/ampproject/amppackager)"
 
 // Advised against, per
-// https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#stateful-headers,
+// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-4.1
 // and blocked in http://crrev.com/c/958945.
 var statefulResponseHeaders = map[string]bool{
 	"Authentication-Control":    true,
@@ -147,7 +147,8 @@ func validateFetch(req *http.Request, resp *http.Response) *HTTPError {
 		return NewHTTPError(http.StatusBadGateway, "Non-OK fetch: ", resp.StatusCode)
 	}
 	// Validate response is publicly-cacheable, per
-	// https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#security-considerations.
+	// https://tools.ietf.org/html/draft-yasskin-http-origin-signed-responses-03#section-6.1, as referenced by
+	// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-6.
 	// TODO(twifkak): Set {PrivateCache: false} after we switch from
 	// fetching through the AMP CDN to fetching directly and using the
 	// transformer API. For now, the AMP CDN validates that the origin
@@ -293,7 +294,7 @@ func (this Packager) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	now := time.Now()
 	signer := signedexchange.Signer{
 		// Expires - Date must be <= 604800 seconds, per
-		// https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#signature-validity.
+		// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-3.5.
 		Date:        now.Add(-24 * time.Hour),
 		Expires:     now.Add(6 * 24 * time.Hour),
 		Certs:       []*x509.Certificate{this.cert},


### PR DESCRIPTION
Changed the URLs to point to their latest (hopefully final) location,
and added some words to the disclaimer to clarify that this is only a
proof of concept at the moment.