### PR TITLE
Prelaunch cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,11 @@ cookielessly.
 
 To account for possible clock skew in user agents, the packager back-dates
 packages by 24h, which means they effectively last only 6 days for most users.
+
+This tool only packages AMP documents. To sign non-AMP documents, look at the
+commandline tools on which this was based, at
+https://github.com/nyaxt/webpackage/tree/master/go/signedexchange. This is a
+temporary fork for the implementation snapshot of the spec, and should be seen
+as a reference implementation, and not a supported library. Proper usage
+requires following the status of browser implementations and updating callers to
+import the correct library snapshot.

--- a/certcache.go
+++ b/certcache.go
@@ -48,7 +48,9 @@ func (this CertCache) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	println("path", req.URL.Path)
 	if req.URL.Path == path.Join("/", CertURLPrefix, url.PathEscape(this.certName)) {
 		// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-3.3
-		resp.Header().Set("Content-Type", "application/octet-stream")
+		// This content-type is not standard, but included to reduce
+		// the chance that faulty user agents employ content sniffing.
+		resp.Header().Set("Content-Type", "application/tls-certificate-chain")
 		resp.Header().Set("Cache-Control", "public, max-age=604800")
 		resp.Header().Set("ETag", "\""+this.certName+"\"")
 		// TODO(twifkak): Add cache headers.

--- a/packager.go
+++ b/packager.go
@@ -229,17 +229,19 @@ func NewPackager(cert *x509.Certificate, key crypto.PrivateKey, packagerBase str
 	return &Packager{cert, key, validityURL, &client, baseURL, urlSets}, nil
 }
 
-func (this Packager) fetchURL(url *url.URL) (*http.Request, *http.Response, *HTTPError) {
+func (this Packager) fetchURL(orig *url.URL) (*http.Request, *http.Response, *HTTPError) {
+	// Make a copy so destructive changes don't persist.
+	fetch := *orig
 	// Add the query parameter to enable web package transforms.
-	query := url.Query()
+	query := fetch.Query()
 	query.Add("usqp", "mq331AQCSAE")
-	url.RawQuery = query.Encode()
+	fetch.RawQuery = query.Encode()
 
 	ampURL := AmpCDNBase
-	if url.Scheme == "https" {
+	if fetch.Scheme == "https" {
 		ampURL += "s/"
 	}
-	ampURL += url.Host + url.RequestURI()
+	ampURL += fetch.Host + fetch.RequestURI()
 
 	log.Printf("Fetching URL: %q\n", ampURL)
 	// TODO(twifkak): Translate into AMP CDN URL, until transform API is available.

--- a/packager_test.go
+++ b/packager_test.go
@@ -76,6 +76,22 @@ func TestSimple(t *testing.T) {
 	assert.Equal(t, fakeBody, exchange.Payload)
 }
 
+func TestNoFetchParam(t *testing.T) {
+	urlSets := []URLSet{URLSet{
+		Sign:  &URLPattern{[]string{"https"}, "", "example.com", stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+	}}
+	resp := get(t, newPackager(t, urlSets), `/priv/doc?sign=https%3A%2F%2Fexample.com%2Famp%2Fsecret-life-of-pine-trees.html`)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("incorrect status: %#v", resp)
+	}
+	exchange, err := signedexchange.ReadExchangeFile(resp.Body)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, "/s/example.com/amp/secret-life-of-pine-trees.html?usqp=mq331AQCSAE", lastRequestURL)
+	assert.Equal(t, "https://example.com/amp/secret-life-of-pine-trees.html", exchange.RequestUri.String())
+}
+
 func TestMain(m *testing.M) {
 	// Mock out AMP CDN endpoint.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
- Fix signed URL when &fetch= is unspecified.
- Add doc reference to nyaxt/webpackage.
- Change cert mime type.