### PR TITLE
Serve a null validity map at /amppkg/validity

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -106,7 +106,7 @@ func main() {
 
 	// TODO(twifkak): Make log output configurable.
 	mux := http.NewServeMux()
-	mux.Handle(amppkg.ValidityMapURL, validityMap)
+	mux.Handle(path.Join("/", amppkg.ValidityMapURL), validityMap)
 	mux.Handle("/priv/doc", packager)
 	mux.Handle(path.Join("/", amppkg.CertURLPrefix)+"/", certCache)
 	addr := ""

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -91,6 +91,10 @@ func main() {
 	}
 	// TODO(twifkak): Verify that key matches cert.
 
+	validityMap, err := amppkg.NewValidityMap()
+	if err != nil {
+		die(errors.Wrap(err, "building validity map"))
+	}
 	packager, err := amppkg.NewPackager(cert, key, config.PackagerBase, config.URLSet)
 	if err != nil {
 		die(errors.Wrap(err, "building packager"))
@@ -102,6 +106,7 @@ func main() {
 
 	// TODO(twifkak): Make log output configurable.
 	mux := http.NewServeMux()
+	mux.Handle(amppkg.ValidityMapURL, validityMap)
 	mux.Handle("/priv/doc", packager)
 	mux.Handle(path.Join("/", amppkg.CertURLPrefix)+"/", certCache)
 	addr := ""

--- a/packager.go
+++ b/packager.go
@@ -218,8 +218,10 @@ func NewPackager(cert *x509.Certificate, key crypto.PrivateKey, packagerBase str
 	if !acceptablePackagerSchemes[baseURL.Scheme] {
 		return nil, errors.Errorf("PackagerBase %q must be over http or https.", packagerBase)
 	}
-	validityURL := baseURL
-	validityURL.Path = ValidityMapURL
+	validityURL, err := url.Parse(path.Join(packagerBase, ValidityMapURL))
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing PackagerBase %q with ValidityMapURL %q", packagerBase, ValidityMapURL)
+	}
 	client := http.Client{
 		// TODO(twifkak): Load-test and see if default transport settings are okay.
 		Timeout: 60 * time.Second,

--- a/packager.go
+++ b/packager.go
@@ -218,10 +218,8 @@ func NewPackager(cert *x509.Certificate, key crypto.PrivateKey, packagerBase str
 	if !acceptablePackagerSchemes[baseURL.Scheme] {
 		return nil, errors.Errorf("PackagerBase %q must be over http or https.", packagerBase)
 	}
-	validityURL, err := url.Parse("https://cdn.ampproject.org/null-validity")
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing null-validity URL")
-	}
+	validityURL := baseURL
+	validityURL.Path = ValidityMapURL
 	client := http.Client{
 		// TODO(twifkak): Load-test and see if default transport settings are okay.
 		Timeout: 60 * time.Second,

--- a/packager.go
+++ b/packager.go
@@ -218,7 +218,8 @@ func NewPackager(cert *x509.Certificate, key crypto.PrivateKey, packagerBase str
 	if !acceptablePackagerSchemes[baseURL.Scheme] {
 		return nil, errors.Errorf("PackagerBase %q must be over http or https.", packagerBase)
 	}
-	validityURL, err := url.Parse(path.Join(packagerBase, ValidityMapURL))
+	// packagerBase is always quaranteed to have a trailing slash due to config.go
+	validityURL, err := url.Parse(packagerBase + ValidityMapURL)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing PackagerBase %q with ValidityMapURL %q", packagerBase, ValidityMapURL)
 	}

--- a/packager.go
+++ b/packager.go
@@ -218,7 +218,7 @@ func NewPackager(cert *x509.Certificate, key crypto.PrivateKey, packagerBase str
 	if !acceptablePackagerSchemes[baseURL.Scheme] {
 		return nil, errors.Errorf("PackagerBase %q must be over http or https.", packagerBase)
 	}
-	// packagerBase is always quaranteed to have a trailing slash due to config.go
+	// packagerBase is always guaranteed to have a trailing slash due to config.go
 	validityURL, err := url.Parse(packagerBase + ValidityMapURL)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing PackagerBase %q with ValidityMapURL %q", packagerBase, ValidityMapURL)

--- a/util.go
+++ b/util.go
@@ -32,5 +32,5 @@ func CertName(cert *x509.Certificate) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-// ValidityMapURL
-const ValidityMapURL = "/amppkg/validity"
+// ValidityMapURL must start without a slash, for PackagerBase's sake.
+const ValidityMapURL = "amppkg/validity"


### PR DESCRIPTION
Addresses #22	

Also adds new validity url to the packager instead of the AMP CDN.
`validityUrl="http://{domain{:port}}/amppkg/validity"`