### PR TITLE
Fix test error in errors.go.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -28,7 +28,7 @@ type HTTPError struct {
 }
 
 func NewHTTPError(statusCode int, msg ...interface{}) *HTTPError {
-	return &HTTPError{fmt.Sprint(msg), statusCode}
+	return &HTTPError{fmt.Sprint(msg...), statusCode}
 }
 
 func (e HTTPError) Error() string { return e.InternalMsg }


### PR DESCRIPTION
The error is:

./errors.go:31: missing ... in args forwarded to print-like function

And shows when I run `go test`, but not `go build`. This must be a new
error as of Go 1.10; I haven't changed this code in a long time.