### PR TITLE
Fix CertCache by removing the pemContent param.

### DIFF
--- a/certcache.go
+++ b/certcache.go
@@ -30,7 +30,7 @@ type CertCache struct {
 	cert     *x509.Certificate
 }
 
-func NewCertCache(cert *x509.Certificate, pemContent []byte) (*CertCache, error) {
+func NewCertCache(cert *x509.Certificate) (*CertCache, error) {
 	this := new(CertCache)
 	this.certName = CertName(cert)
 	this.cert = cert


### PR DESCRIPTION
This was obviated in #55 (5701013b), but I forgot to remove the param
here to match the change to cmd/amppkg/main.go.