### PR TITLE
Fix certcache_test per pemContent removal.

### DIFF
--- a/certcache_test.go
+++ b/certcache_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func newCertCache(t *testing.T) *CertCache {
-	handler, err := NewCertCache(cert, certPem)
+	handler, err := NewCertCache(cert)
 	if err != nil {
 		t.Fatal(errors.WithStack(err))
 	}

--- a/util_for_test.go
+++ b/util_for_test.go
@@ -28,25 +28,15 @@ import (
 )
 
 // A self-signed cert for testing.
-var certPem = func() []byte {
-	ret, _ := ioutil.ReadFile("testdata/cert.pem")
-	return ret
-}()
-
-// The same cert, parsed.
 var cert = func() *x509.Certificate {
+	certPem, _ := ioutil.ReadFile("testdata/cert.pem")
 	certs, _ := signedexchange.ParseCertificates(certPem)
 	return certs[0]
 }()
 
 // Its corresponding private key.
-var keyPem = func() []byte {
-	ret, _ := ioutil.ReadFile("testdata/privkey.pem")
-	return ret
-}()
-
-// The same key, parsed.
 var key = func() crypto.PrivateKey {
+	keyPem, _ := ioutil.ReadFile("testdata/privkey.pem")
 	keyBlock, _ := pem.Decode(keyPem)
 	key, _ := signedexchange.ParsePrivateKey(keyBlock.Bytes)
 	return key


### PR DESCRIPTION
The test was broken by the removal of the pemContent param in #59
(7bd10db4).