### PR TITLE
Fix code and documentation per v=b1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ and signs AMP documents as requested by the AMP Cache.
 
 #### Configure your frontend server
 
-The frontend server needs to forward two types of requests to the packager:
-packages and certificates.
+The frontend server needs to forward three types of requests to the packager:
+packages, certificates, and validity maps.
 
 ##### Packages
 
@@ -79,9 +79,9 @@ Let's break that down:
 
 ##### Certificates
 
-AMP Packages will contain a `certUrl` that indicates the certificate that can be
-used to validate the package. The `certUrl` may be on any domain, and it may be
-HTTP or HTTPS, but it will have a path of the form:
+AMP Packages will contain a `cert-url` that indicates the certificate that can
+be used to validate the package. The `cert-url` may be on any domain, and it may
+be HTTP or HTTPS, but it will have a path of the form:
 
 ```
 /amppkg/cert/blahblahblah
@@ -91,6 +91,15 @@ where `blahblahblah` is a base64 encoding of a hash of the public certificate.
 You may optionally prefix such URLs' paths, via the config file. The frontend
 server must internally reverse-proxy these requests to the packager (without the
 custom prefix).
+
+##### Validity maps
+
+AMP Packages will also contain a `validity-url`. This must be on the same domain
+as the signed URL. It will have a path of the form:
+
+```
+/amppkg/validity
+```
 
 #### Configure the packager
 

--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -5,7 +5,7 @@
 # LocalOnly = true
 
 # This is the URL prefix under which the packager is being served on the open
-# internet. This is used to generate certUrls, by appending
+# internet. This is used to generate cert-urls, by appending
 # "/amppkg/cert/blahblahblah". (In the future, it may have other uses.) This is
 # NOT the URL where the packager responds, which will instead be anchored to
 # the root path.
@@ -30,8 +30,10 @@ PackagerBase = 'https://example.com/'
 # "blahblahblah" is a stable unique identifier for the cert (currently, its
 # base64-encoded SHA-256).
 #
-# This certificate must be 2048-bit RSA using the SHA-256 signing algorithm.
-# (See https://goo.gl/pwK9EJ item 4.1.5.)
+# This certificate must use an EC P-256 key. (See https://goo.gl/pwK9EJ item
+# 3.1.5.) It must have at least one SCT, either as an X.509 extension or as an
+# extension to the OCSP responses from the URI mentioned in its Authority
+# Information Access extension. (See https://goo.gl/JQiyNs item 7.4.)
 #
 # To mitigate the risk of an attacker gaining access to your private key
 # through a vulnerability in this packager, you should generate a new

--- a/certcache.go
+++ b/certcache.go
@@ -124,8 +124,7 @@ func (this *CertCache) CreateCertChainCBOR() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating cert-chain+cbor")
 	}
-	// TODO(twifkak): Specify real SCT blob.
-	return certurl.CreateCertChainCBOR(this.certs, ocsp, []byte{})
+	return certurl.CreateCertChainCBOR(this.certs, ocsp, nil)
 }
 
 func (this *CertCache) ServeHTTP(resp http.ResponseWriter, req *http.Request, params httprouter.Params) {
@@ -133,7 +132,7 @@ func (this *CertCache) ServeHTTP(resp http.ResponseWriter, req *http.Request, pa
 		// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-3.3
 		// This content-type is not standard, but included to reduce
 		// the chance that faulty user agents employ content sniffing.
-		resp.Header().Set("Content-Type", "application/tls-certificate-chain")
+		resp.Header().Set("Content-Type", "application/cert-chain+cbor")
 		resp.Header().Set("Cache-Control", "public, max-age=604800")
 		resp.Header().Set("ETag", "\""+this.certName+"\"")
 		cbor, err := this.CreateCertChainCBOR()

--- a/certcache_test.go
+++ b/certcache_test.go
@@ -155,10 +155,10 @@ func (this *CertCacheSuite) DecodeCBOR(r io.Reader) map[string][]byte {
 	// Decode and return the first one.
 	numKeys, err := decoder.DecodeMapHeader()
 	this.Require().NoError(err, "decoding map header")
-	this.Require().EqualValues(3, numKeys)
+	this.Require().EqualValues(2, numKeys)
 
 	ret := map[string][]byte{}
-	for i := 0; i < 3; i++ {
+	for i := 0; uint64(i) < numKeys; i++ {
 		key, err := decoder.DecodeTextString()
 		this.Require().NoError(err, "decoding key")
 		value, err := decoder.DecodeByteString()
@@ -174,7 +174,7 @@ func (this *CertCacheSuite) TestServesCertificate() {
 	cbor := this.DecodeCBOR(resp.Body)
 	this.Assert().Contains(cbor, "cert")
 	this.Assert().Contains(cbor, "ocsp")
-	this.Assert().Contains(cbor, "sct")
+	this.Assert().NotContains(cbor, "sct")
 }
 
 func (this *CertCacheSuite) TestServes404OnMissingCertificate() {

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -135,4 +135,7 @@ func main() {
 	// TCP keep-alive timeout on ListenAndServe is 3 minutes. To shorten,
 	// follow the above Cloudflare blog.
 	log.Fatal(server.ListenAndServe())
+
+	// To test this, place a TLS-terminating proxy in front of it, or
+	// change ListenAndServe() above to ListenAndServeTLS(certFile, keyFile).
 }

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -103,7 +103,7 @@ func main() {
 	mux := httprouter.New()
 	mux.RedirectTrailingSlash = false
 	mux.RedirectFixedPath = false
-	mux.GET(path.Join("/", amppkg.ValidityMapURL), validityMap.ServeHTTP)
+	mux.GET(path.Join("/", amppkg.ValidityMapPath), validityMap.ServeHTTP)
 	mux.GET("/priv/doc", packager.ServeHTTP)
 	mux.GET("/priv/doc/*signURL", packager.ServeHTTP)
 	mux.GET(path.Join("/", amppkg.CertURLPrefix)+"/:certName", certCache.ServeHTTP)

--- a/config.go
+++ b/config.go
@@ -166,8 +166,9 @@ func ReadConfig(configPath string) (*Config, error) {
 	if config.OCSPCache == "" {
 		return nil, errors.New("must specify OCSPCache")
 	}
-	if stat, err := os.Stat(filepath.Base(config.OCSPCache)); os.IsNotExist(err) || !stat.Mode().IsDir() {
-		return nil, errors.New("OCSPCache parent directory must exist")
+	ocspDir := filepath.Dir(config.OCSPCache)
+	if stat, err := os.Stat(ocspDir); os.IsNotExist(err) || !stat.Mode().IsDir() {
+		return nil, errors.Errorf("OCSPCache parent directory must exist: %s", ocspDir)
 	}
 	// TODO(twifkak): Verify OCSPCache is writable by the current user.
 	if len(config.URLSet) == 0 {

--- a/packager.go
+++ b/packager.go
@@ -447,7 +447,7 @@ func (this *Packager) ServeHTTP(resp http.ResponseWriter, req *http.Request, par
 		return
 	}
 	now := time.Now()
-	validityHRef, err := url.Parse("/" + ValidityMapURL)
+	validityHRef, err := url.Parse("/" + ValidityMapPath)
 	if err != nil {
 		NewHTTPError(http.StatusInternalServerError, "Error building validity href: ", err).LogAndRespond(resp)
 	}

--- a/util.go
+++ b/util.go
@@ -37,8 +37,8 @@ func CertName(cert *x509.Certificate) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-// ValidityMapURL must start without a slash, for PackagerBase's sake.
-const ValidityMapURL = "amppkg/validity"
+// ValidityMapPath must start without a slash.
+const ValidityMapPath = "amppkg/validity"
 
 // ParsePrivateKey returns the first PEM block that looks like a private key.
 func ParsePrivateKey(keyPem []byte) (crypto.PrivateKey, error) {


### PR DESCRIPTION
Update cert requirements, validity-url generation, SCT generation and
documentation, cert-chain+cbor content-type, OCSP cache dir check,
inner content-type (text/html) and outer content-type (b0 -> b1).

This has been tested with a real SXG certificate against Chrome M69.

Fixes #35. Fixes #15. Addresses #36.