### PR TITLE
Move top-level go files into packager/.

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/pkg/errors"
 
-	amppkg "github.com/ampproject/amppackager"
+	amppkg "github.com/ampproject/amppackager/packager"
 )
 
 var flagConfig = flag.String("config", "amppkg.toml", "Path to the config toml file.")
@@ -98,7 +98,7 @@ func main() {
 	if err != nil {
 		die(errors.Wrap(err, "initializing rtv cache"))
 	}
-	err = rtvCache.StartCron()
+	err = rtvCache.StartCron("")
 	if err != nil {
 		die(errors.Wrap(err, "starting rtv cron"))
 	}

--- a/packager/certcache.go
+++ b/packager/certcache.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"bytes"

--- a/packager/certcache_test.go
+++ b/packager/certcache_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"crypto/rsa"
@@ -37,13 +37,13 @@ import (
 const certName = "k9GCZZIDzAt2X0b2czRv0c2omW5vgYNh6ZaIz_UNTRQ"
 
 var caCert = func() *x509.Certificate {
-	certPem, _ := ioutil.ReadFile("testdata/b1/ca.cert")
+	certPem, _ := ioutil.ReadFile("../testdata/b1/ca.cert")
 	certs, _ := signedexchange.ParseCertificates(certPem)
 	return certs[0]
 }()
 
 var caKey = func() *rsa.PrivateKey {
-	keyPem, _ := ioutil.ReadFile("testdata/b1/ca.privkey")
+	keyPem, _ := ioutil.ReadFile("../testdata/b1/ca.privkey")
 	key, _ := ParsePrivateKey(keyPem)
 	return key.(*rsa.PrivateKey)
 }()

--- a/packager/config.go
+++ b/packager/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"os"

--- a/packager/errors.go
+++ b/packager/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"fmt"

--- a/packager/packager.go
+++ b/packager/packager.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"bytes"

--- a/packager/packager_test.go
+++ b/packager/packager_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"bytes"

--- a/packager/rtv.go
+++ b/packager/rtv.go
@@ -1,4 +1,4 @@
-package amppackager
+package packager
 
 import (
 	"encoding/json"

--- a/packager/rtv_test.go
+++ b/packager/rtv_test.go
@@ -1,4 +1,4 @@
-package amppackager
+package packager
 
 import (
 	"fmt"

--- a/packager/storage.go
+++ b/packager/storage.go
@@ -1,4 +1,4 @@
-package amppackager
+package packager
 
 import (
 	"context"

--- a/packager/util.go
+++ b/packager/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"crypto"

--- a/packager/util_for_test.go
+++ b/packager/util_for_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"crypto"
@@ -28,14 +28,14 @@ import (
 
 // A cert (with its issuer chain) for testing.
 var certs = func() []*x509.Certificate {
-	certPem, _ := ioutil.ReadFile("testdata/b1/fullchain.cert")
+	certPem, _ := ioutil.ReadFile("../testdata/b1/fullchain.cert")
 	certs, _ := signedexchange.ParseCertificates(certPem)
 	return certs
 }()
 
 // Its corresponding private key.
 var key = func() crypto.PrivateKey {
-	keyPem, _ := ioutil.ReadFile("testdata/b1/server.privkey")
+	keyPem, _ := ioutil.ReadFile("../testdata/b1/server.privkey")
 	key, _ := ParsePrivateKey(keyPem)
 	return key
 }()

--- a/packager/validitymap.go
+++ b/packager/validitymap.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package amppackager
+package packager
 
 import (
 	"bytes"


### PR DESCRIPTION
Also, fix a bug in main.go where it wasn't calling StartCron() with the
right number of args.

Fixes #28.