### PR TITLE
Fallback to unsigned if AMP-Cache-Transform wrong.

### DIFF
--- a/packager/amp_cache_transform/amp_cache_transform.go
+++ b/packager/amp_cache_transform/amp_cache_transform.go
@@ -1,0 +1,139 @@
+// Parses and interprets the AMP-Cache-Transform header specified at
+// https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-transform.md.
+
+package amp_cache_transform
+
+import (
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.3
+type parameterisedIdentifier struct {
+	id     string
+	// In the future, this will include params.
+}
+
+// https://tools.ietf.org/html/rfc7230#appendix-B (OWS = "optional whitespace")
+func discardOWS(reader *strings.Reader) error {
+	for reader.Len() > 0 {
+		c, err := reader.ReadByte()
+		if err != nil {
+			return errors.Wrap(err, "reading OWS")
+		}
+		if c != ' ' && c != '\t' {
+			// Return to the position before the non-whitespace char.
+			reader.Seek(-1, io.SeekCurrent)
+			return nil
+		}
+	}
+	return nil
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2.3
+func parseParameterisedList(reader *strings.Reader) ([]parameterisedIdentifier, error) {
+	items := []parameterisedIdentifier{}
+	for reader.Len() > 0 {
+		item, err := parseParameterisedIdentifier(reader)
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing parameterised identifier")
+		}
+		items = append(items, *item)
+		// Steps 3 and 4 are swapped per https://github.com/httpwg/http-extensions/pull/667.
+		if reader.Len() == 0 {
+			return items, nil
+		}
+		if err := discardOWS(reader); err != nil {
+			return nil, errors.Wrap(err, "discarding OWS")
+		}
+		comma, err := reader.ReadByte()
+		if err != nil {
+			return nil, errors.Wrap(err, "reading comma")
+		}
+		if comma != ',' {
+			return nil, errors.New("expected comma")
+		}
+		if err := discardOWS(reader); err != nil {
+			return nil, errors.Wrap(err, "discarding OWS")
+		}
+		if reader.Len() == 0 {
+			return nil, errors.New("expected another param-id")
+		}
+	}
+	return nil, errors.New("reached unexpected end of parseParameterisedList")
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2.4
+func parseParameterisedIdentifier(reader *strings.Reader) (*parameterisedIdentifier, error) {
+	primaryID, err := parseIdentifier(reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing primary identifier")
+	}
+	// NOTE: The initial version of AMP-Cache-Transform does not support
+	// any parameters, so we don't bother to implement a parser for them.
+	// No point in distinguishing syntactic failure from semantic failure.
+	// Once we add parameters, we'll need to implement parsers for the
+	// subset item that they use. See Items here:
+	// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.4
+	return &parameterisedIdentifier{primaryID}, nil
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.8
+func isIdentifier(c byte) bool {
+	return isLCAlpha(c) || isDigit(c) || c == '_' || c == '-' || c == '*' || c == '/'
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.8
+func isLCAlpha(c byte) bool {
+	return c >= 'a' && c <= 'z'
+}
+
+// https://tools.ietf.org/html/rfc5234#appendix-B.1
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2.8
+func parseIdentifier(reader *strings.Reader) (string, error) {
+	var output strings.Builder
+	char, err := reader.ReadByte()
+	if err != nil {
+		return "", errors.Wrap(err, "reading byte")
+	}
+	if !isLCAlpha(char) {
+		return "", errors.New("expected lowercase alpha")
+	}
+	output.WriteByte(char)
+	for ; reader.Len() > 0; {
+		char, err := reader.ReadByte()
+		if err != nil {
+			return "", errors.Wrap(err, "reading byte")
+		}
+		if !isIdentifier(char) {
+			// Return to the position before the non-identifier char.
+			reader.Seek(-1, io.SeekCurrent)
+			return output.String(), nil
+		}
+		output.WriteByte(char)
+	}
+	return output.String(), nil
+}
+
+// Returns true if the given AMP-Cache-Transform request header value is one
+// the packager can satisfy.
+func ShouldSendSXG(header_value string) bool {
+	reader := strings.NewReader(header_value)
+	identifiers, err := parseParameterisedList(reader)
+	if err != nil {
+		// TODO(twifkak): Debug-log err and reader.Len() bytes remaining.
+		return false
+	}
+	for _, identifier := range identifiers {
+		if identifier.id == "any" || identifier.id == "google" {
+			return true
+		}
+	}
+	return false
+}

--- a/packager/amp_cache_transform/amp_cache_transform.go
+++ b/packager/amp_cache_transform/amp_cache_transform.go
@@ -62,7 +62,7 @@ func parseParameterisedList(reader *strings.Reader) ([]parameterisedIdentifier, 
 			return nil, errors.New("expected another param-id")
 		}
 	}
-	return nil, errors.New("reached unexpected end of parseParameterisedList")
+	return nil, errors.New("expected non-empty parameterised list")
 }
 
 // https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2.4
@@ -81,11 +81,6 @@ func parseParameterisedIdentifier(reader *strings.Reader) (*parameterisedIdentif
 }
 
 // https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.8
-func isIdentifier(c byte) bool {
-	return isLCAlpha(c) || isDigit(c) || c == '_' || c == '-' || c == '*' || c == '/'
-}
-
-// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.8
 func isLCAlpha(c byte) bool {
 	return c >= 'a' && c <= 'z'
 }
@@ -93,6 +88,11 @@ func isLCAlpha(c byte) bool {
 // https://tools.ietf.org/html/rfc5234#appendix-B.1
 func isDigit(c byte) bool {
 	return c >= '0' && c <= '9'
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.8
+func isSecondIdentifierChar(c byte) bool {
+	return isLCAlpha(c) || isDigit(c) || c == '_' || c == '-' || c == '*' || c == '/'
 }
 
 // https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2.8
@@ -111,7 +111,7 @@ func parseIdentifier(reader *strings.Reader) (string, error) {
 		if err != nil {
 			return "", errors.Wrap(err, "reading byte")
 		}
-		if !isIdentifier(char) {
+		if !isSecondIdentifierChar(char) {
 			// Return to the position before the non-identifier char.
 			reader.Seek(-1, io.SeekCurrent)
 			return output.String(), nil

--- a/packager/amp_cache_transform/amp_cache_transform_test.go
+++ b/packager/amp_cache_transform/amp_cache_transform_test.go
@@ -1,0 +1,23 @@
+package amp_cache_transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldSendSXG(t *testing.T) {
+	assert.True(t, ShouldSendSXG("any"))
+	assert.True(t, ShouldSendSXG("google"))
+	assert.True(t, ShouldSendSXG("google, any"))
+	assert.True(t, ShouldSendSXG("google, foobar"))
+	assert.True(t, ShouldSendSXG("foobar, any"))
+
+	assert.False(t, ShouldSendSXG(""))
+	assert.False(t, ShouldSendSXG(" any"))
+	assert.False(t, ShouldSendSXG("any "))
+	assert.False(t, ShouldSendSXG("foobar"))
+	assert.False(t, ShouldSendSXG("foobar, baz"))
+	assert.False(t, ShouldSendSXG("google;any"))
+	assert.False(t, ShouldSendSXG("google;v=1"))
+}

--- a/packager/amp_cache_transform/amp_cache_transform_test.go
+++ b/packager/amp_cache_transform/amp_cache_transform_test.go
@@ -11,6 +11,10 @@ func TestShouldSendSXG(t *testing.T) {
 	assert.True(t, ShouldSendSXG("google"))
 	assert.True(t, ShouldSendSXG("google, any"))
 	assert.True(t, ShouldSendSXG("google, foobar"))
+	assert.True(t, ShouldSendSXG("google,foobar"))
+	assert.True(t, ShouldSendSXG("google,\tfoobar"))
+	assert.True(t, ShouldSendSXG("google ,foobar"))
+	assert.True(t, ShouldSendSXG("google, a*b-c_d/e"))
 	assert.True(t, ShouldSendSXG("foobar, any"))
 
 	assert.False(t, ShouldSendSXG(""))
@@ -18,6 +22,10 @@ func TestShouldSendSXG(t *testing.T) {
 	assert.False(t, ShouldSendSXG("any "))
 	assert.False(t, ShouldSendSXG("foobar"))
 	assert.False(t, ShouldSendSXG("foobar, baz"))
+	assert.False(t, ShouldSendSXG("googleany"))
 	assert.False(t, ShouldSendSXG("google;any"))
 	assert.False(t, ShouldSendSXG("google;v=1"))
+	assert.False(t, ShouldSendSXG("google,123"))
+	assert.False(t, ShouldSendSXG("google, eh!"))
+	assert.False(t, ShouldSendSXG("ABC,google"))
 }

--- a/packager/certcache_test.go
+++ b/packager/certcache_test.go
@@ -189,6 +189,7 @@ func (this *CertCacheSuite) TestOCSP() {
 	resp := getP(this.T(), this.handler, "/amppkg/cert/"+certName, httprouter.Params{httprouter.Param{"certName", certName}})
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
 	// 302400 is 3.5 days. max-age is slightly less because of the time between fake OCSP generation and cert-chain response.
+	// TODO(twifkak): Make this less flaky, by injecting a fake clock.
 	this.Assert().Equal("public, max-age=302399", resp.Header.Get("Cache-Control"))
 	cbor := this.DecodeCBOR(resp.Body)
 	this.Assert().Equal(this.fakeOCSP, cbor["ocsp"])

--- a/packager/util_for_test.go
+++ b/packager/util_for_test.go
@@ -49,8 +49,22 @@ func get(t *testing.T, handler AlmostHandler, target string) *http.Response {
 	return getP(t, handler, target, httprouter.Params{})
 }
 
+func getH(t *testing.T, handler AlmostHandler, target string, headers http.Header) *http.Response {
+	return getHP(t, handler, target, headers, httprouter.Params{})
+}
+
 func getP(t *testing.T, handler AlmostHandler, target string, params httprouter.Params) *http.Response {
+	return getHP(t, handler, target, http.Header{}, params)
+}
+
+func getHP(t *testing.T, handler AlmostHandler, target string, headers http.Header, params httprouter.Params) *http.Response {
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest("", target, nil), params)
+	req := httptest.NewRequest("", target, nil)
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+	handler.ServeHTTP(rec, req, params)
 	return rec.Result()
 }


### PR DESCRIPTION
For now, this means that it should contain an unparameterised `any` or
`google`.

Fixes #84.