### PR TITLE
Update README.md to be more action-oriented.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,10 @@ Copy `amppkg.example.toml` to `amppkg.toml` and modify it to suit your needs.
 You may use `testdata/b1/server.{cert,privkey}` to get started. However, you are
 at your own risk if you instruct your browser to trust `server.cert`. *NEVER*
 instruct your browser to trust `ca.cert`.
+
+# Suggestions for contributions
+
+Take a look at [good first
+issues](https://github.com/ampproject/amppackager/labels/good%20first%20issue),
+and please communicate early and often, to ensure we agree on the solution
+before you invest a lot of time into its implementation.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ By running it in a proper configuration, web publishers may (eventually) have
 origin URLs appear in AMP search results.
 
 The AMP Packager works by creating [Signed HTTP
-Exchanges (SXGs)](https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00)
+Exchanges (SXGs)](https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html)
 containing AMP documents, signed with a certificate associated with the origin,
 with a maximum lifetime of 7 days. In the future, the [Google AMP
 Cache](https://www.ampproject.org/docs/fundamentals/how_cached) will fetch,

--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@
 > of it, as a proof of concept. Feel free to play around with it, but be
 > cautious. Examine the code.
 
-AMP Packager creates "AMP Packages" (implemented as [Signed HTTP
-Exchanges](https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00))
-containing AMP documents. These packages are consumed by the [Google AMP
-Cache](https://www.ampproject.org/docs/fundamentals/how_cached) and cached.
-Eventually, a future variant of these packages will be linked to from Google
-Search instead of normal AMP page. The packages are signed with a certificate,
-which means that Chrome users will see that certificate's domain in the URL bar
-instead of `google.com` or `ampproject.org`, and that the web page will run on
-that origin.
+AMP Packager is a tool to [improve AMP
+URLs](https://amphtml.wordpress.com/2018/01/09/improving-urls-for-amp-pages/).
+By running it in a proper configuration, web publishers may (eventually) have
+origin URLs appear in AMP search results.
 
-These packages have a maximum lifetime of 7 days, which minimizes the risk of
-another cache serving a stale copy of this signed content. In the future, the
-[AMP update-cache API](https://developers.google.com/amp/cache/update-cache)
-will support updating AMP Packages, though it doesn't yet.
+It works by creating [Signed HTTP
+Exchanges (SXGs)](https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00))
+containing AMP documents, signed with a certificate associated with the origin,
+with a maximum lifetime of 7 days. In the near future, the [Google AMP
+Cache](https://www.ampproject.org/docs/fundamentals/how_cached) will ingest,
+cache, and serve them, similar to how it does for normal AMP HTML documents.
+When a user loads such an SXG, Chrome validates the signature and then displays
+certificate's domain in the URL bar instead of `google.com`, and runs the web
+page on that origin.
 
 The packager is an HTTP server that sits behind a frontend server; it fetches
 and signs AMP documents as requested by the AMP Cache.
@@ -27,165 +27,142 @@ and signs AMP documents as requested by the AMP Cache.
 
 ### How to use
 
-#### Configure your frontend server
+In all the instructions below, replace `example.com` with a domain you own and
+can obtain certificates for.
 
-The frontend server needs to forward three types of requests to the packager:
-packages, certificates, and validity maps.
+#### Development server
 
-##### Packages
+  1. Install Go version 1.10 or higher. Optionally, set
+     [$GOPATH](https://github.com/golang/go/wiki/GOPATH) to something (default
+     is `~/go`) and/or add `$GOPATH/bin` to `$PATH`.
+  2. `go get -u github.com/ampproject/amppackager/cmd/amppkg`
 
-The frontend needs to forward requests for web packages to the packager. The
-details of this are still being worked out, but for now, an easy way to do so is
-by URL. Come up with a simple URL mapping between an AMP package URL and its
-corresponding AMP HTML URL. For instance, you might append `.htxg` to the URL,
-so for an AMP URL:
+     Optionally, move the built `~/go/bin/amppkg` wherever you like.
+  3. Create a file `amppkg.toml`. A minimal config looks like this:
+     ```
+     LocalOnly = true
+     PackagerBase = 'https://localhost:8080/'
+     CertFile = 'path/to/fullchain.pem'
+     KeyFile = 'path/to/privkey.pem'
+     OCSPCache = '/tmp/amppkg/ocsp'
 
-```
-https://example.com/url/to/amp.html
-```
+     [[URLSet]]
+       [URLSet.Sign]
+         Domain = "example.com"
+     ```
+     More details can be found in [amppkg.example.toml](amppkg.example.toml).
+  4. `mkdir /tmp/amppkg`
+  5. `amppkg -development`
 
-the corresponding AMP package URL would be:
-
-```
-https://example.com/url/to/amp.html.htxg
-```
-
-The frontend server should then internally reverse-proxy such a request to
-something like:
-
-```
-http://packager.internal/priv/doc?sign=https%3A%2F%2Fexample.com%2Furl%2Fto%2Famp.html
-```
-
-Let's break that down:
-
-  `http://` The packager itself only knows how to serve HTTP. Connections to it
-  should remain inside your network. If you want encryption-in-transit (for
-  instance if the connection to the packager travels outside your network), you
-  may place a TLS-terminating proxy in front of it.
-
-  `packager.internal` This is the host (and optionally port) of the packager as
-  known to the frontend server.
-
-  `/priv/doc` This is a fixed string. The frontend server must rewrite
-  the URL to start with this.
-
-  `?sign=https%3A%2F%2Fexample.com%2Furl%2Fto%2Famp.html` The location that
-  should appear in the browser's URL bar, URL-escaped for use in a query. This
-  must be HTTPS, and must be on a domain that the packager's certificate can
-  sign for. If the user hits Refresh on their browser, it will fetch from this
-  URL. By default, the content for the package is fetched from this same URL
-  anonymously (e.g. without a `Cookie` header). It may not contain a fragment.
-
-##### Certificates
-
-AMP Packages will contain a `cert-url` that indicates the certificate that can
-be used to validate the package. The `cert-url` may be on any domain, and it may
-be HTTP or HTTPS, but it will have a path of the form:
-
-```
-/amppkg/cert/blahblahblah
-```
-
-where `blahblahblah` is a base64 encoding of a hash of the public certificate.
-You may optionally prefix such URLs' paths, via the config file. The frontend
-server must internally reverse-proxy these requests to the packager (without the
-custom prefix).
-
-##### Validity maps
-
-AMP Packages will also contain a `validity-url`. This must be on the same domain
-as the signed URL. It will have a path of the form:
-
-```
-/amppkg/validity
-```
-
-#### Configure the packager
-
-The packager needs to be set up to receive reverse-proxied requests from the
-frontend as specified above. In addition, it:
-
-  * Must not be accessible on the open internet (even by IP address). To do so
-    removes defense-in-depth against allowing external parties to fetch
-    arbitrary documents and sign them with different arbitrary URLs.
-  * Must have a certificate/key pair for all the domains you wish to sign. If
-    you want to sign for multiple domains with different certificates, then run
-    different instances of the packager. We recommend using a different
-    certificate/key pair from your normal web-serving traffic. See the example
-    config file for details.
-  * Must be able to make outgoing connections to `cdn.ampproject.org` on port
-    443.
-  * Should have its stdout redirected to a log file somewhere, probably rotated.
-  * Should not run as superuser.
-
-<!-- TODO(twifkak): Add instructions for getting an API key or service account,
-     after the Transformer API is in place. Maybe make a script that automates
-     it using gcloud. -->
-
-Once you've chosen a setup that meets the above constraints, actual
-configuration is fairly straightforward:
-
-  1. `go get github.com/ampproject/amppackager/cmd/amppkg`
-  2. Move the built `~/go/bin/amppkg` wherever you like.
-  3. Create a packager config file; use `amppkg.example.toml` in this repo as a template.
-  4. Launch with `/path/to/amppkg -config=/path/to/amppkg.toml >>/path/to/amppkg.log`.
-  5. Set up log rotation for `amppkg.log`.
+     If `amppkg.toml` is not in the current working directory, pass
+     `-config=/path/to/amppkg.toml`.
 
 #### Test your config
 
-  1. Run a [Chrome Canary](https://www.google.com/chrome/browser/canary.html),
-     or if on Linux, a [nightly build of
-     Chromium](https://www.chromium.org/getting-involved/download-chromium).
-  2. Navigate to chrome://flags#enable-signed-http-exchange and enable that
-     feature.
-  3. Navigate to your AMP package URL (i.e. the `href` of your
-     `<link rel="amppackage">` for a given page).
-  4. Watch the URL transmogrify!
+  1. Run Chrome M70 or later (as of 2018-09-18, this is Beta or Dev). On the
+     command-line, pass the following flags:
+     ```
+     --user-data-dir=/tmp/udd
+     --ignore-certificate-errors-spki-list=$(openssl x509 -pubkey -noout -in path/to/fullchain.pem | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64)
+     --enable-features=SignedHTTPExchange
+     'data:text/html,<a href="https://localhost:8080/priv/doc/https://example.com/">click me'
+     ```
+  2. Open DevTools. Check 'Preserve log'.
+  3. Click the `click me` link.
+  4. Watch the URL transmogrify! Verify it came from an SXG by switching
+     DevTools to the Network tab and looking in the Size column for "(from
+     signed-exchange)".
 
-Optionally, you may pretend to be an AMP Cache:
+#### Demonstrate privacy-preserving prefetch
 
-  1. Use `wget` to download the package and save it as a `foo.htxg` file.
-  2. `go run cmd/amppkg_test_cache/main.go -package=path/to/foo.htxg`
-  3. Ensure the packager is still running; it's needed to serve the certificate.
-  4. Visit `http://localhost:8000/` in the experimental Chromium.
+This step is optional; just to show how [privacy-preserving
+prefetch](https://wicg.github.io/webpackage/draft-yasskin-webpackage-use-cases.html#private-prefetch)
+works with SXGs.
 
-#### How will these web packages be discovered?
+  1. `go get -u github.com/ampproject/amppackager/cmd/amppkg_dl_sxg`.
+  2. `amppkg_dl_sxg https://localhost:8080/priv/doc/https://example.com/`
+  3. Stop `amppkg` with Ctrl-C.
+  4. `go get -u github.com/ampproject/amppackager/cmd/amppkg_test_cache`.
+  5. `amppkg_test_cache`
+  6. Open Chrome and DevTools.
+  7. Visit `https://localhost:8000/`. Observe the prefetch of `/test.sxg`.
+  8. Click the link. Observe that the cached SXG is used.
 
-The details of that are still being worked out. We have several alternatives in
-mind and want to come up with an answer that's best for the web, including
-crawlers, sites serving packages, sites not serving packages, and package
-caches. If you have any constraints or suggestions, please comment on issue #5,
-or feel free to reach out in private if needed.
+#### Productionizing
+
+For now, productionizing is a bit manual. We would love to see a Docker
+container that builds in the best practices!
+
+The minimum steps are:
+
+  1. Don't pass `-development` flag to `amppkg`. This causes it to serve HTTP
+     rather than HTTPS.
+  2. Don't expose `amppkg` to the outside world; keep it on your internal
+     network.
+  3. Configure your TLS-serving frontend server to conditionally proxy to
+     `amppkg`, if any of:
+     1. The URL starts with `/amppkg/`.
+     2. The URL is AMP and the `AMP-Cache-Transform` request header is present.
+  4. Configure your frontend server to add `Vary: AMP-Cache-Transform` if the
+     URL is AMP. This should occur for both HTML and SXG responses.
+  5. Get an SXG cert from your CA. It must use an EC key with the prime256v1
+     algorithm, and it must have a [CanSignHttpExchanges
+     extension](https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#cross-origin-cert-req).
+     You MUST use this in `amppkg.toml`, and MUST NOT use it in your frontend.
+
+You may also want to:
+
+  1. Launch `amppkg` as a restricted user.
+  2. Save its stdout to a rotated log somewhere.
+
+Once you've done the above, you should be able to launch Chrome without any
+flags; just make sure chrome://flags/#enable-signed-http-exchange is enabled.
+
+#### Replicating
+
+If you need to set up multiple replicas of `amppkg` for scale, you'll want your
+`OCSPCache` to be backed by a shared storage device (e.g. NFS). It doesn't need
+to be shared among all instances globally, but perhaps among all instances per
+datacenter. The reason for this is to reduce the number of OCSP requests
+`amppkg` needs to make, per [OCSP stapling
+recommendations](https://gist.github.com/sleevi/5efe9ef98961ecfb4da8).
+
+#### How will these web packages be discovered by Google?
+
+For now, the presence of the `Vary: AMP-Cache-Transform` response header on an
+AMP HTML page will cause the Google AMP Cache to make a second request with
+`AMP-Cache-Transform: google` for the SXG.
+
+In the future, Googlebot may make all requests with `AMP-Cache-Transform: google`,
+eliminating the second fetch. It would be able to "unwrap" these SXGs and use
+them for Search.
 
 ### Limitations
 
 Currently, the packager will refuse to sign any AMP documents larger than 4 MB.
+Patches that allow for streamed signing are welcome.
 
-The Go http.Client implementation doesn't support redirect chains that rely on
-cookies being set and then read later in the chain; all requests are made
-cookielessly.
+If the packager refuses to sign any URL that results in a redirect. This is by
+design, as neither the original URL nor the final URL makes sense as the signed
+URL.
 
 To account for possible clock skew in user agents, the packager back-dates
 packages by 24h, which means they effectively last only 6 days for most users.
 
 This tool only packages AMP documents. To sign non-AMP documents, look at the
 commandline tools on which this was based, at
-https://github.com/WICG/webpackage/tree/master/go/signedexchange. This should be
-seen as a reference implementation, and not a supported library. Proper usage
-requires following the status of browser implementations and updating callers to
-import the correct library snapshot.
+https://github.com/WICG/webpackage/tree/master/go/signedexchange.
 
 ## Local Transformer
 
-The local transformer is a sub-library within the AMP Packager that transforms AMP HTML for security and performance improvements. These modifications are described in more detail [here](https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-modifications.md).
+The local transformer is a sub-library within the AMP Packager that transforms AMP HTML for security and performance improvements. These modifications are described in more detail [here](https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-modifications.md). Note that the transformed AMP HTML produced by the library is only valid inside of a signed exchange, and not to be served this as normal HTML.
 
 > **WARNING**: This local transformer library is still a work-in-progress and not all transformations described in the link above are implemented.
 
 ### How to use
 The local transformer can be used separately from the packager/signer.
 
-1. `go get github.com/ampproject/amppackager/cmd/transform`
+1. `go get -u github.com/ampproject/amppackager/cmd/transform`
 1. `$GOPATH/bin/transform -url "documentURL" /path/to/html`
 
 For more help, `$GOPATH/bin/transform -h`

--- a/README.md
+++ b/README.md
@@ -92,10 +92,7 @@ works with SXGs.
 
 #### Productionizing
 
-For now, productionizing is a bit manual. We would love to see scripts or
-packages that build in the best practices!
-
-The minimum steps are:
+For now, productionizing is a bit manual. The minimum steps are:
 
   1. Don't pass `-development` flag to `amppkg`. This causes it to serve HTTP
      rather than HTTPS.
@@ -121,12 +118,12 @@ Once you've done the above, you should be able to launch Chrome without any
 comamndline flags; just make sure chrome://flags/#enable-signed-http-exchange is
 enabled.
 
-#### Replicating
+#### Redundancy
 
-If you need to set up multiple replicas of `amppkg` for scale, you'll want your
-`OCSPCache` to be backed by a shared storage device (e.g. NFS). It doesn't need
-to be shared among all instances globally, but perhaps among all instances per
-datacenter. The reason for this is to reduce the number of OCSP requests
+If you need to load balance across multiple instances of `amppkg`, you'll want
+your `OCSPCache` to be backed by a shared storage device (e.g. NFS). It doesn't
+need to be shared among all instances globally, but perhaps among all instances
+per datacenter. The reason for this is to reduce the number of OCSP requests
 `amppkg` needs to make, per [OCSP stapling
 recommendations](https://gist.github.com/sleevi/5efe9ef98961ecfb4da8).
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ URLs](https://amphtml.wordpress.com/2018/01/09/improving-urls-for-amp-pages/).
 By running it in a proper configuration, web publishers may (eventually) have
 origin URLs appear in AMP search results.
 
-It works by creating [Signed HTTP
-Exchanges (SXGs)](https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00))
+The AMP Packager works by creating [Signed HTTP
+Exchanges (SXGs)](https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00)
 containing AMP documents, signed with a certificate associated with the origin,
-with a maximum lifetime of 7 days. In the near future, the [Google AMP
-Cache](https://www.ampproject.org/docs/fundamentals/how_cached) will ingest,
-cache, and serve them, similar to how it does for normal AMP HTML documents.
+with a maximum lifetime of 7 days. In the future, the [Google AMP
+Cache](https://www.ampproject.org/docs/fundamentals/how_cached) will fetch,
+cache, and serve them, similar to what it does for normal AMP HTML documents.
 When a user loads such an SXG, Chrome validates the signature and then displays
-certificate's domain in the URL bar instead of `google.com`, and runs the web
-page on that origin.
+the certificate's domain in the URL bar instead of `google.com`, and treats the
+web page as though it were on that domain.
 
 The packager is an HTTP server that sits behind a frontend server; it fetches
 and signs AMP documents as requested by the AMP Cache.
@@ -59,7 +59,9 @@ can obtain certificates for.
 
 #### Test your config
 
-  1. Run Chrome M70 or later (as of 2018-09-18, this is Beta or Dev). On the
+  1. Run Chrome M70 or later (as of 2018-09-18, this is
+     [Beta](https://www.google.com/chrome/beta/) or
+     [Dev](https://www.google.com/chrome/dev/)). On the
      command-line, pass the following flags:
      ```
      --user-data-dir=/tmp/udd
@@ -90,8 +92,8 @@ works with SXGs.
 
 #### Productionizing
 
-For now, productionizing is a bit manual. We would love to see a Docker
-container that builds in the best practices!
+For now, productionizing is a bit manual. We would love to see scripts or
+packages that build in the best practices!
 
 The minimum steps are:
 
@@ -116,7 +118,8 @@ You may also want to:
   2. Save its stdout to a rotated log somewhere.
 
 Once you've done the above, you should be able to launch Chrome without any
-flags; just make sure chrome://flags/#enable-signed-http-exchange is enabled.
+comamndline flags; just make sure chrome://flags/#enable-signed-http-exchange is
+enabled.
 
 #### Replicating
 
@@ -130,19 +133,18 @@ recommendations](https://gist.github.com/sleevi/5efe9ef98961ecfb4da8).
 #### How will these web packages be discovered by Google?
 
 For now, the presence of the `Vary: AMP-Cache-Transform` response header on an
-AMP HTML page will cause the Google AMP Cache to make a second request with
+AMP HTML page will allow the Google AMP Cache to make a second request with
 `AMP-Cache-Transform: google` for the SXG.
 
 In the future, Googlebot may make all requests with `AMP-Cache-Transform: google`,
-eliminating the second fetch. It would be able to "unwrap" these SXGs and use
-them for Search.
+eliminating the double fetch.
 
 ### Limitations
 
 Currently, the packager will refuse to sign any AMP documents larger than 4 MB.
 Patches that allow for streamed signing are welcome.
 
-If the packager refuses to sign any URL that results in a redirect. This is by
+The packager refuses to sign any URL that results in a redirect. This is by
 design, as neither the original URL nor the final URL makes sense as the signed
 URL.
 
@@ -155,14 +157,8 @@ https://github.com/WICG/webpackage/tree/master/go/signedexchange.
 
 ## Local Transformer
 
-The local transformer is a sub-library within the AMP Packager that transforms AMP HTML for security and performance improvements. These modifications are described in more detail [here](https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-modifications.md). Note that the transformed AMP HTML produced by the library is only valid inside of a signed exchange, and not to be served this as normal HTML.
+The local transformer is a library within the AMP Packager that transforms AMP
+HTML for security and performance improvements. Ports of or alternatives to the
+AMP Packager will need to include these transforms.
 
-> **WARNING**: This local transformer library is still a work-in-progress and not all transformations described in the link above are implemented.
-
-### How to use
-The local transformer can be used separately from the packager/signer.
-
-1. `go get -u github.com/ampproject/amppackager/cmd/transform`
-1. `$GOPATH/bin/transform -url "documentURL" /path/to/html`
-
-For more help, `$GOPATH/bin/transform -h`
+More info [here](transformer/README.md).

--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -1,5 +1,8 @@
 # This is a TOML 0.4.0 file, as specified by https://github.com/toml-lang/toml.
 
+# The port to listen on; 8080 is the default.
+# Port = 8080
+
 # Uncomment this line to serve only to localhost clients, e.g. for testing, by
 # binding on the loopback interface.
 # LocalOnly = true

--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -8,10 +8,8 @@
 # LocalOnly = true
 
 # This is the URL prefix under which the packager is being served on the open
-# internet. This is used to generate cert-urls, by appending
-# "/amppkg/cert/blahblahblah". (In the future, it may have other uses.) This is
-# NOT the URL where the packager responds, which will instead be anchored to
-# the root path.
+# internet. This is used to generate cert-urls and validity-urls, by appending
+# "/amppkg/cert/blahblahblah" and "/amppkg/validity". This is
 #
 # For instance, if PackagerBase = "https://example.com/", then the frontend
 # server should reverse-proxy all URLs matching:

--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -105,6 +105,13 @@ OCSPCache = '/tmp/amppkg/ocsp'
   # content from the same location. If you'd like more flexibility (for
   # instance, to fetch content from an edge node), uncomment this section. This
   # allows the frontend to specify an additional `fetch` query parameter.
+  # Instead of looking like:
+  #
+  #   /priv/doc/https://example.com/page.html
+  #
+  # The URL will look like:
+  #
+  #   /priv/doc?fetch=https%3A%2F%2Finternal.example.com%2Fpage.html&sign=https%3A%2F%2Fexample.com%2Fpage.html
   #
   # Note that this reduces the defense-in-depth against the "signing oracle"
   # attack. If an attacker can request custom URLs from the packager (or

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -35,6 +35,7 @@ import (
 )
 
 var flagConfig = flag.String("config", "amppkg.toml", "Path to the config toml file.")
+var flagDevelopment = flag.Bool("development", false, "True if this is a development server.")
 
 // Prints errors returned by pkg/errors with stack traces.
 func die(err interface{}) { log.Fatalf("%+v", err) }
@@ -145,8 +146,11 @@ func main() {
 
 	// TCP keep-alive timeout on ListenAndServe is 3 minutes. To shorten,
 	// follow the above Cloudflare blog.
-	log.Fatal(server.ListenAndServe())
 
-	// To test this, place a TLS-terminating proxy in front of it, or
-	// change ListenAndServe() above to ListenAndServeTLS(certFile, keyFile).
+	if (*flagDevelopment) {
+		log.Println("WARNING: Running in development, using SXG key for TLS. This won't work in production.")
+		log.Fatal(server.ListenAndServeTLS(config.CertFile, config.KeyFile))
+	} else {
+		log.Fatal(server.ListenAndServe())
+	}
 }

--- a/cmd/amppkg_dl_sxg/main.go
+++ b/cmd/amppkg_dl_sxg/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/WICG/webpackage/go/signedexchange"
+	"github.com/pkg/errors"
+)
+
+var flagOutSXG = flag.String("out_sxg", "test.sxg", "Path to where the signed-exchange should be saved.")
+var flagOutCert = flag.String("out_cert", "test.cert", "Path to where the cert-chain+cbor should be saved.")
+
+func getSXG(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	req.Header.Set("Accept", "application/signed-exchange;v=b2")
+	req.Header.Set("AMP-Cache-Transform", "any")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return body, nil
+}
+
+func extractCertURL(sxg []byte) (string, error) {
+	exchange, err := signedexchange.ReadExchange(bytes.NewReader(sxg))
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	// Short of implementing a structured-headers-07 parser, we simply
+	// regex for the value as returned by
+	// signedexchange.Signer.signatureHeaderValue().
+	re, err := regexp.Compile(`"; cert-url=(".*"); cert-sha256=\*`)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	matches := re.FindStringSubmatch(exchange.SignatureHeaderValue)
+	if matches == nil {
+		return "", errors.Errorf("no cert-url found in %s", exchange.SignatureHeaderValue)
+	}
+	quotedCertURL := matches[1]
+	certURL, err := strconv.Unquote(quotedCertURL)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return certURL, nil
+}
+
+func getCert(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return body, nil
+}
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "Usage:", os.Args[0], "<url_of_sxg>\n")
+		fmt.Fprintln(os.Stderr, "Saves a copy of the SXG and cert-chain, to be served with amppkg_test_cache.\n")
+		flag.Usage()
+		return
+	}
+	sxg, err := getSXG(flag.Arg(0))
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	certURL, err := extractCertURL(sxg)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	err = ioutil.WriteFile(*flagOutSXG, sxg, 0644)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	cert, err := getCert(certURL)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	err = ioutil.WriteFile(*flagOutCert, cert, 0644)
+	if err != nil {
+		log.Fatalf("%+v", err)
+	}
+	fmt.Fprintf(os.Stderr, "Saved to %s and %s.\n", *flagOutSXG, *flagOutCert)
+}

--- a/testdata/b1/README.md
+++ b/testdata/b1/README.md
@@ -15,7 +15,7 @@ $ cat server.cert ca.cert >fullchain.cert
 ```
 
 <!--
-TODO(twifkak): Use  k
+TODO(twifkak): Update this to add CanSignHttpExchanges extension.
 TODO(twifkak): Update this to add AIA for OCSP.
 https://www.feistyduck.com/library/openssl-cookbook/online/ch-openssl.html
 https://github.com/grimm-co/GOCSP-responder

--- a/transformer/README.md
+++ b/transformer/README.md
@@ -1,0 +1,21 @@
+# Local Transformer
+
+The modifications in this package are described in more detail
+[here](https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-modifications.md).
+
+> NOTE: The transformed AMP HTML produced by the library is only valid inside of
+> a signed exchange, and not to be served as normal HTML. Also, the library is
+> still a work-in-progress and not all transformations described in the link
+> above are implemented.
+
+## How to use
+The local transformer can be used separately from the packager/signer. Here's an
+example use of the binary:
+
+1. `go get -u github.com/ampproject/amppackager/cmd/transform`
+1. `$GOPATH/bin/transform -url "documentURL" /path/to/html`
+
+For more help, `$GOPATH/bin/transform -h`
+
+See the [binary source code](../cmd/transform/transform.go) for an example use
+of the library.


### PR DESCRIPTION
Reverse the overall order of instructions to start with `amppkg` and
end with the frontend configuration, so that incremental progress can be
seen. Focus on commands to run and keep explanations brief.

Update the tooling to make it easy to demonstrate privacy-preserving
prefetch.

Addresses #79.