### PR TITLE
Remove PackagerBase.

### DIFF
--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -7,25 +7,6 @@
 # binding on the loopback interface.
 # LocalOnly = true
 
-# This is the URL prefix under which the packager is being served on the open
-# internet. This is used to generate cert-urls and validity-urls, by appending
-# "/amppkg/cert/blahblahblah" and "/amppkg/validity". This is
-#
-# For instance, if PackagerBase = "https://example.com/", then the frontend
-# server should reverse-proxy all URLs matching:
-#   https://example.com/amppkg/(.*)
-# to the packager.
-#
-# Alternatively, if PackagerBase = "https://example.com/packager/", then the
-# frontend server should reverse-proxy all URLs matching:
-#   https://example.com/packager/amppkg/(.*)
-# to the packager, removing the "/packager" prefix from the path.
-#
-# The frontend MUST NOT forward any requests for /amppkg-priv/.* to the
-# packager. Doing so would allow users to sign the wrong URL on documents. (See
-# URLSet below for some mitigation of this.)
-PackagerBase = 'https://example.com/'
-
 # The path to the PEM file containing the full certificate chain, ordered from
 # leaf to root. This will be served at /amppkg/cert/blahblahblah, where
 # "blahblahblah" is a stable unique identifier for the cert (currently, its

--- a/cmd/amppkg_dl_sxg/main.go
+++ b/cmd/amppkg_dl_sxg/main.go
@@ -77,8 +77,8 @@ func getCert(url string) ([]byte, error) {
 func main() {
 	flag.Parse()
 	if flag.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "Usage:", os.Args[0], "<url_of_sxg>\n")
-		fmt.Fprintln(os.Stderr, "Saves a copy of the SXG and cert-chain, to be served with amppkg_test_cache.\n")
+		fmt.Fprint(os.Stderr, "Usage: ", os.Args[0], " <url_of_sxg>\n\n")
+		fmt.Fprint(os.Stderr, "Saves a copy of the SXG and cert-chain, to be served with amppkg_test_cache.\n\n")
 		flag.Usage()
 		return
 	}

--- a/cmd/amppkg_test_cache/main.go
+++ b/cmd/amppkg_test_cache/main.go
@@ -35,9 +35,9 @@ var flagPort = flag.Int("port", 8000, "Port to serve on.")
 func main() {
 	flag.Parse()
 	if flag.NArg() != 2 {
-		fmt.Fprintln(os.Stderr, "Usage:", os.Args[0], "<cert_pem> <key_pem>\n")
-		fmt.Fprintln(os.Stderr, "Serves the test SXG and cert-chain as an AMP Cache might.")
-		fmt.Fprintln(os.Stderr, "Pass it a TLS certificate pair you wish to serve with.\n")
+		fmt.Fprint(os.Stderr, "Usage: ", os.Args[0], " <cert_pem> <key_pem>\n\n")
+		fmt.Fprint(os.Stderr, "Serves the test SXG and cert-chain as an AMP Cache might.\n")
+		fmt.Fprint(os.Stderr, "Pass it a TLS certificate pair you wish to serve with.\n\n")
 		flag.Usage()
 		return
 	}

--- a/packager/config.go
+++ b/packager/config.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
@@ -27,7 +26,6 @@ import (
 type Config struct {
 	LocalOnly    bool
 	Port         int
-	PackagerBase string // The base URL under which /amppkg/ URLs will be served on the internet.
 	CertFile     string // This must be the full certificate chain.
 	KeyFile      string // Just for the first cert, obviously.
 	OCSPCache    string
@@ -152,10 +150,6 @@ func ReadConfig(configPath string) (*Config, error) {
 
 	if config.Port == 0 {
 		config.Port = 8080
-	}
-	if !strings.HasSuffix(config.PackagerBase, "/") {
-		// This ensures that the ResolveReference call doesn't replace the last path component.
-		config.PackagerBase += "/"
 	}
 	if config.CertFile == "" {
 		return nil, errors.New("must specify CertFile")

--- a/packager/packager_test.go
+++ b/packager/packager_test.go
@@ -79,7 +79,7 @@ func newPackager(t *testing.T, urlSets []URLSet) *Packager {
 }
 
 func newPackagerShouldPackage(t *testing.T, urlSets []URLSet, shouldPackage bool) *Packager {
-	handler, err := NewPackager(certs[0], key, "https://example.com/", urlSets, &rtv.RTVCache{}, func() bool { return shouldPackage })
+	handler, err := NewPackager(certs[0], key, urlSets, &rtv.RTVCache{}, func() bool { return shouldPackage }, nil)
 	if err != nil {
 		t.Fatal(errors.WithStack(err))
 	}

--- a/packager/util.go
+++ b/packager/util.go
@@ -25,8 +25,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CertURLPrefix must start without a slash, for PackagerBase's sake.
-const CertURLPrefix = "amppkg/cert"
+const CertURLPrefix = "/amppkg/cert"
 
 // CertName returns the basename for the given cert, as served by this
 // packager's cert cache. Should be stable and unique (e.g.
@@ -37,8 +36,7 @@ func CertName(cert *x509.Certificate) string {
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-// ValidityMapPath must start without a slash.
-const ValidityMapPath = "amppkg/validity"
+const ValidityMapPath = "/amppkg/validity"
 
 // ParsePrivateKey returns the first PEM block that looks like a private key.
 func ParsePrivateKey(keyPem []byte) (crypto.PrivateKey, error) {


### PR DESCRIPTION
It is confusing, and also wrong, now that the validity-url must be
same-origin with the signed URL. Instead, the behavior is thus:

1. validity-url is computed using the origin of the signed URL. It
   doesn't matter if this doesn't actually exist; the browser doesn't
   currently fetch it.
2. In development, the cert-url is localhost, so that you can test with
   a browser.
3. In production, the cert-url is computed using the origin of the
   signed URL. The README.md states that publishers must configure this
   when productionizing.

Fixes #79.

Ignore the first 4 commits; they will be rebased away.