### PR TITLE
Require CanSignHttpExchanges in production.

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -52,7 +52,7 @@ type logIntercept struct {
 func canSignHttpExchanges(cert *x509.Certificate) bool {
 	for _, ext := range cert.Extensions {
 		// 0x05, 0x00 is the DER encoding of NULL.
-		if ext.Id.Equal(asn1.ObjectIdentifier{1,3,6,1,4,1,11129,2,1,22}) && bytes.Equal(ext.Value, []byte{0x05, 0x00}) {
+		if ext.Id.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 11129, 2, 1, 22}) && bytes.Equal(ext.Value, []byte{0x05, 0x00}) {
 			return true
 		}
 	}
@@ -173,7 +173,7 @@ func main() {
 	// TCP keep-alive timeout on ListenAndServe is 3 minutes. To shorten,
 	// follow the above Cloudflare blog.
 
-	if (*flagDevelopment) {
+	if *flagDevelopment {
 		log.Println("WARNING: Running in development, using SXG key for TLS. This won't work in production.")
 		log.Fatal(server.ListenAndServeTLS(config.CertFile, config.KeyFile))
 	} else {

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -18,6 +18,9 @@
 package main
 
 import (
+	"bytes"
+	"crypto/x509"
+	"encoding/asn1"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -43,6 +46,17 @@ func die(err interface{}) { log.Fatalf("%+v", err) }
 
 type logIntercept struct {
 	handler http.Handler
+}
+
+// https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#cross-origin-cert-req
+func canSignHttpExchanges(cert *x509.Certificate) bool {
+	for _, ext := range cert.Extensions {
+		// 0x05, 0x00 is the DER encoding of NULL.
+		if ext.Id.Equal(asn1.ObjectIdentifier{1,3,6,1,4,1,11129,2,1,22}) && bytes.Equal(ext.Value, []byte{0x05, 0x00}) {
+			return true
+		}
+	}
+	return false
 }
 
 func (this logIntercept) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
@@ -79,6 +93,9 @@ func main() {
 	}
 	if certs == nil || len(certs) == 0 {
 		die(fmt.Sprintf("no cert found in %s", config.CertFile))
+	}
+	if !*flagDevelopment && !canSignHttpExchanges(certs[0]) {
+		die("cert is missing CanSignHttpExchanges extension")
 	}
 	// TODO(twifkak): Verify that certs[0] covers all the signing domains in the config.
 

--- a/packager/amp_cache_transform/amp_cache_transform.go
+++ b/packager/amp_cache_transform/amp_cache_transform.go
@@ -12,7 +12,7 @@ import (
 
 // https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.3
 type parameterisedIdentifier struct {
-	id     string
+	id string
 	// In the future, this will include params.
 }
 
@@ -106,7 +106,7 @@ func parseIdentifier(reader *strings.Reader) (string, error) {
 		return "", errors.New("expected lowercase alpha")
 	}
 	output.WriteByte(char)
-	for ; reader.Len() > 0; {
+	for reader.Len() > 0 {
 		char, err := reader.ReadByte()
 		if err != nil {
 			return "", errors.Wrap(err, "reading byte")

--- a/packager/config.go
+++ b/packager/config.go
@@ -24,12 +24,12 @@ import (
 )
 
 type Config struct {
-	LocalOnly    bool
-	Port         int
-	CertFile     string // This must be the full certificate chain.
-	KeyFile      string // Just for the first cert, obviously.
-	OCSPCache    string
-	URLSet       []URLSet
+	LocalOnly bool
+	Port      int
+	CertFile  string // This must be the full certificate chain.
+	KeyFile   string // Just for the first cert, obviously.
+	OCSPCache string
+	URLSet    []URLSet
 }
 
 type URLSet struct {

--- a/packager/packager.go
+++ b/packager/packager.go
@@ -376,7 +376,7 @@ func (this *Packager) ServeHTTP(resp http.ResponseWriter, req *http.Request, par
 		// charset=utf-8 would be redundant, as it is specified in the <meta> of a valid AMPHTML document:
 		fetchResp.Header.Set("Content-Type", "text/html")
 		fetchResp.Header.Set("Content-Security-Policy", contentSecurityPolicy)
-		fetchResp.Header.Del("Link")  // Ensure there are no privacy-violating Link:rel=preload headers.
+		fetchResp.Header.Del("Link") // Ensure there are no privacy-violating Link:rel=preload headers.
 
 		this.serveSignedExchange(resp, fetchResp, signURL)
 

--- a/packager/util_test.go
+++ b/packager/util_test.go
@@ -1,0 +1,14 @@
+package packager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanSignHttpExchanges(t *testing.T) {
+	// Leaf node has the extension.
+	assert.True(t, CanSignHttpExchanges(certs[0]))
+	// CA node does not.
+	assert.False(t, CanSignHttpExchanges(certs[1]))
+}


### PR DESCRIPTION
This prevents users from accidentally using their TLS cert pairs to sign
exchanges, as such SXGs would get rejected by the browser.

Fixes #110.