### PR TITLE
Delete unused imports in cmd/amppkg.

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -18,8 +18,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/asn1"
 	"flag"
 	"fmt"
 	"io/ioutil"


### PR DESCRIPTION
Broken by 73c5d31c (#116). I had the changes open in vim, but forgot to
save.