### PR TITLE
Serve unsigned if `Accept` is unacceptable.

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -118,7 +118,8 @@ func main() {
 		}
 	}
 
-	packager, err := amppkg.NewPackager(certs[0], key, config.URLSet, rtvCache, certCache.IsHealthy, overrideBaseURL)
+	packager, err := amppkg.NewPackager(certs[0], key, config.URLSet, rtvCache, certCache.IsHealthy,
+		overrideBaseURL, /*requireHeaders=*/!*flagDevelopment)
 	if err != nil {
 		die(errors.Wrap(err, "building packager"))
 	}

--- a/packager/accept/accept.go
+++ b/packager/accept/accept.go
@@ -1,0 +1,45 @@
+package accept
+
+import (
+	"mime"
+	"regexp"
+)
+
+// The SXG version that packager can produce. In the future, it may need to be
+// able to produce multiple versions.
+const AcceptedSxgVersion = "b2"
+
+// A comma, as would appear in an Accept header. Comma-separation is defined
+// in https://tools.ietf.org/html/rfc7230#section-7, with OWS defined in
+// https://tools.ietf.org/html/rfc7230#appendix-B.
+//
+// There is an edge case on which this fails:
+//   Accept: application/signed-exchange;junk="some,thing";v=b2
+// However, in practice, browsers don't send media types with quoted
+// commas in them:
+//   https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
+// So we'll live with this deficiency for the sake of not forking
+// mime.ParseMediaType.
+var comma *regexp.Regexp = func() *regexp.Regexp {
+	re, err := regexp.Compile(`[ \t]*,[ \t]*`)
+	if err != nil {
+		panic(err)
+	}
+	return re
+}()
+
+// True if the given Accept header is one that the packager can satisfy. It
+// must contain application/signed-exchange;v=$V so that the packager knows
+// whether or not it can supply the correct version. "" and "*/*" are not
+// satisfiable, for this reason.
+func CanSatisfy(accept string) bool {
+	types := comma.Split(accept, -1)
+	for _, mediaRange := range types {
+		mediatype, params, err := mime.ParseMediaType(mediaRange)
+		if err == nil && mediatype == "application/signed-exchange" && params["v"] == AcceptedSxgVersion {
+			return true
+		}
+	}
+	return false
+}
+

--- a/packager/accept/accept_test.go
+++ b/packager/accept/accept_test.go
@@ -1,0 +1,25 @@
+package accept
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanSatisfy(t *testing.T) {
+	assert.False(t, CanSatisfy(""))
+	assert.False(t, CanSatisfy("*/*"))
+	assert.False(t, CanSatisfy("image/jpeg;v=b2"))
+	// This is a bug, though one which won't occur in practice:
+	assert.False(t, CanSatisfy(`application/signed-exchange;x="a,b";v="b2"`))
+
+	assert.True(t, CanSatisfy(`application/signed-exchange;v=b2`))
+	assert.True(t, CanSatisfy(`application/signed-exchange;v="b2"`))
+	assert.True(t, CanSatisfy(`application/signed-exchange;v=b2;q=0.8`))
+	assert.True(t, CanSatisfy(`application/signed-exchange;v=b1,application/signed-exchange;v=b2`))
+	assert.True(t, CanSatisfy(`application/signed-exchange;x="v=b1";v="b2"`))
+	assert.True(t, CanSatisfy("*/*, application/signed-exchange;v=b2"))
+	assert.True(t, CanSatisfy("*/* \t,\t application/signed-exchange;v=b2"))
+	// This is the same bug:
+	assert.True(t, CanSatisfy(`application/signed-exchange;x="y,application/signed-exchange;v=b2,z";v=b1`))
+}

--- a/packager/packager_test.go
+++ b/packager/packager_test.go
@@ -79,7 +79,7 @@ func newPackager(t *testing.T, urlSets []URLSet) *Packager {
 }
 
 func newPackagerShouldPackage(t *testing.T, urlSets []URLSet, shouldPackage bool) *Packager {
-	handler, err := NewPackager(certs[0], key, urlSets, &rtv.RTVCache{}, func() bool { return shouldPackage }, nil)
+	handler, err := NewPackager(certs[0], key, urlSets, &rtv.RTVCache{}, func() bool { return shouldPackage }, nil, true)
 	if err != nil {
 		t.Fatal(errors.WithStack(err))
 	}
@@ -108,11 +108,11 @@ type PackagerSuite struct {
 }
 
 func (this *PackagerSuite) get(t *testing.T, handler AlmostHandler, target string) *http.Response {
-	return getH(t, handler, target, http.Header{"AMP-Cache-Transform": {"google"}})
+	return this.getP(t, handler, target, httprouter.Params{})
 }
 
 func (this *PackagerSuite) getP(t *testing.T, handler AlmostHandler, target string, params httprouter.Params) *http.Response {
-	return getHP(t, handler, target, http.Header{"AMP-Cache-Transform": {"google"}}, params)
+	return getHP(t, handler, target, http.Header{"AMP-Cache-Transform": {"google"}, "Accept": {"application/signed-exchange;v=b2"}}, params)
 }
 
 func (this *PackagerSuite) TestSimple() {


### PR DESCRIPTION
This has a small bug, but should be able to handle all Accept header
values seen in practice.

This doesn't verify that the Accept header can process the content-type
of the unmodified fetch response, but in practice that should be fine.
https://tools.ietf.org/html/rfc7231#section-3.4.1 and
https://tools.ietf.org/html/rfc7231#section-5.3.2 say ignoring
content-negotiation headers is allowed.

Fixes #109.