### PR TITLE
Proxy unsigned if status code is unrecognized.

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -416,7 +416,8 @@ func (this *Packager) ServeHTTP(resp http.ResponseWriter, req *http.Request, par
 		resp.WriteHeader(http.StatusNotModified)
 
 	default:
-		util.NewHTTPError(http.StatusBadGateway, "Non-OK fetch: ", fetchResp.StatusCode).LogAndRespond(resp)
+		log.Printf("Not packaging because status code %d is unrecognized.\n", fetchResp.StatusCode)
+		proxy(resp, fetchResp)
 	}
 }
 

--- a/packager/util/errors.go
+++ b/packager/util/errors.go
@@ -21,7 +21,10 @@ import (
 )
 
 // HTTPError encodes an internal message to be logged and an HTTP status code
-// to be used for the external error message.
+// to be used for the external error message. External errors should only be
+// used to signal misconfiguration of the packager. For errors that are
+// transient or a result of downstream server errors, the signer should fall
+// back to proxying the content unsigned.
 type HTTPError struct {
 	InternalMsg string
 	StatusCode  int


### PR DESCRIPTION
This provides a more useful error response for the crawler as a result
of a transient downstream change.

All remaining uses of `util.NewHTTPError` are a result of packager
misconfiguration, so it makes sense to be obvious about them.

Fixes #127.