### PR TITLE
Add miscellaneous unit tests.

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -61,9 +61,16 @@ func (this logIntercept) ServeHTTP(resp http.ResponseWriter, req *http.Request) 
 //  - It is in cleartext.
 func main() {
 	flag.Parse()
-	config, err := util.ReadConfig(*flagConfig)
+	if *flagConfig == "" {
+		die("must specify --config")
+	}
+	configBytes, err := ioutil.ReadFile(*flagConfig)
 	if err != nil {
-		die(errors.Wrap(err, "reading config"))
+		die(errors.Wrapf(err, "reading config at %s", *flagConfig))
+	}
+	config, err := util.ReadConfig(configBytes)
+	if err != nil {
+		die(errors.Wrapf(err, "parsing config at %s", *flagConfig))
 	}
 
 	// TODO(twifkak): Document what cert/key storage formats this accepts.

--- a/packager/testing/testing.go
+++ b/packager/testing/testing.go
@@ -37,6 +37,7 @@ var Certs = func() []*x509.Certificate {
 // Its corresponding private key.
 var Key = func() crypto.PrivateKey {
 	keyPem, _ := ioutil.ReadFile("../../testdata/b1/server.privkey")
+	// This call to ParsePrivateKey() is needed by util_test.go.
 	key, _ := util.ParsePrivateKey(keyPem)
 	return key
 }()

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -59,7 +59,7 @@ func validateURLPattern(pattern *URLPattern) error {
 	}
 	for _, exclude := range pattern.PathExcludeRE {
 		if _, err := regexp.Compile(exclude); err != nil {
-			return errors.Errorf("PathExcludeRE contains be invalid regexp %q", exclude)
+			return errors.Errorf("PathExcludeRE contains invalid regexp %q", exclude)
 		}
 	}
 	if pattern.QueryRE == nil {
@@ -134,17 +134,14 @@ func validateFetchURLPattern(pattern *URLPattern) error {
 }
 
 // ReadConfig reads the config file specified at --config and validates it.
-func ReadConfig(configPath string) (*Config, error) {
-	if configPath == "" {
-		return nil, errors.New("must specify --config")
-	}
-	tree, err := toml.LoadFile(configPath)
+func ReadConfig(configBytes []byte) (*Config, error) {
+	tree, err := toml.LoadBytes(configBytes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse config at: %s", configPath)
+		return nil, errors.Wrapf(err, "failed to parse TOML")
 	}
 	config := Config{}
 	if err = tree.Unmarshal(&config); err != nil {
-		return nil, errors.Wrapf(err, "failed to parse config at: %s", configPath)
+		return nil, errors.Wrapf(err, "failed to unmarshal TOML")
 	}
 	// TODO(twifkak): Return an error if the TOML includes any fields that aren't part of the Config struct.
 

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -1,0 +1,267 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func errorFrom(_ *Config, err error) string {
+	return err.Error()
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestInvalid(t *testing.T) {
+	assert.NotEqual(t, "", errorFrom(ReadConfig([]byte(``))))
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`abc`))), "failed to parse TOML")
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`[Port] X=5`))), "failed to unmarshal TOML")
+}
+
+func TestMinimalValidConfig(t *testing.T) {
+	config, err := ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+	`))
+	require.NoError(t, err)
+	assert.Equal(t, Config{
+		Port: 8080,
+		CertFile: "cert.pem",
+		KeyFile: "key.pem",
+		OCSPCache: "/tmp/ocsp",
+		URLSet: []URLSet{{
+			Sign: &URLPattern{
+				Domain: "example.com",
+				PathRE: stringPtr(".*"),
+				QueryRE: stringPtr(".*"),
+			},
+		}},
+	}, *config)
+}
+
+func TestOCSPDirDoesntExist(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/this/does/not/exist/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+	`))), "OCSPCache parent directory must exist")
+}
+
+func TestInvalidPathRE(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		    PathRE = "["
+	`))), "PathRE must be a valid regexp")
+}
+
+func TestInvalidPathExcludeRE(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		    PathExcludeRE = ["["]
+	`))), "PathExcludeRE contains invalid regexp")
+}
+
+func TestInvalidQueryRE(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		    QueryRE = "["
+	`))), "QueryRE must be a valid regexp")
+}
+
+func TestSignMissing(t *testing.T) {
+	msg := errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+	`)))
+	assert.Contains(t, msg, "This section must be specified")
+	assert.Contains(t, msg, "URLSet.0.Sign")
+}
+
+func TestSignScheme(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		    Scheme = ["http"]
+	`))), "Scheme not allowed here")
+}
+
+func TestSignDomainRE(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		    DomainRE = ".*"
+	`))), "DomainRE not allowed here")
+}
+
+func TestSignSamePath(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		    SamePath = true
+	`))), "SamePath not allowed here")
+}
+
+func TestSignOverrides(t *testing.T) {
+	config, err := ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		    PathRE = "/amp/.*"
+		    PathExcludeRE = ["/amp/signin", "/amp/settings(/.*)?"]
+		    QueryRE = ""
+		    ErrorOnStatefulHeaders = true
+	`))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(config.URLSet))
+	// TODO(twifkak): Don't depend on scheme order.
+	assert.Equal(t, URLPattern{
+		Domain: "example.com",
+		PathRE: stringPtr("/amp/.*"),
+		PathExcludeRE: []string{"/amp/signin", "/amp/settings(/.*)?"},
+		QueryRE: stringPtr(""),
+		ErrorOnStatefulHeaders: true,
+	}, *config.URLSet[0].Sign)
+}
+
+func TestFetchDefaults(t *testing.T) {
+	config, err := ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		  [URLSet.Fetch]
+		    Domain = "example.com"
+	`))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(config.URLSet))
+	fetch := *config.URLSet[0].Fetch
+	assert.ElementsMatch(t, []string{"http", "https"}, fetch.Scheme)
+	assert.Equal(t, "", fetch.DomainRE)
+	assert.Equal(t, "example.com", fetch.Domain)
+	assert.Equal(t, stringPtr(".*"), fetch.PathRE)
+	assert.Nil(t, fetch.PathExcludeRE)
+	assert.Equal(t, stringPtr(".*"), fetch.QueryRE)
+	assert.Equal(t, false, fetch.ErrorOnStatefulHeaders)
+	assert.Equal(t, boolPtr(true), fetch.SamePath)
+}
+
+func TestFetchOverrides(t *testing.T) {
+	config, err := ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+		  [URLSet.Fetch]
+		    Scheme = ["http"]
+		    DomainRE = ".*"
+		    PathRE = "/amp/.*"
+		    PathExcludeRE = ["/amp/signin", "/amp/settings(/.*)?"]
+		    QueryRE = ""
+		    SamePath = false
+	`))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(config.URLSet))
+	assert.Equal(t, URLPattern{
+		Scheme: []string{"http"},
+		DomainRE: ".*",
+		PathRE: stringPtr("/amp/.*"),
+		PathExcludeRE: []string{"/amp/signin", "/amp/settings(/.*)?"},
+		QueryRE: stringPtr(""),
+		SamePath: boolPtr(false),
+	}, *config.URLSet[0].Fetch)
+}
+
+func TestFetchInvalidScheme(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Fetch]
+		    Scheme = ["gopher"]
+	`))), "Scheme contains invalid value")
+}
+
+func TestFetchNoDomain(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Fetch]
+	`))), "Domain or DomainRE must be specified")
+}
+
+func TestFetchDomainAndDomainRE(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Fetch]
+		    Domain = "example.com"
+		    DomainRE = "example.com"
+	`))), "Only one of Domain or DomainRE")
+}
+
+func TestFetchErrorOnStatefulHeaders(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		[[URLSet]]
+		  [URLSet.Fetch]
+		    Domain = "example.com"
+		    ErrorOnStatefulHeaders = true
+	`))), "ErrorOnStatefulHeaders not allowed")
+}

--- a/packager/util/errors.go
+++ b/packager/util/errors.go
@@ -34,14 +34,8 @@ func NewHTTPError(statusCode int, msg ...interface{}) *HTTPError {
 	return &HTTPError{fmt.Sprint(msg...), statusCode}
 }
 
-func (e *HTTPError) Error() string { return e.InternalMsg }
-
-func (e *HTTPError) ExternalMsg() string {
-	return http.StatusText(e.StatusCode)
-}
-
 func (e *HTTPError) LogAndRespond(resp http.ResponseWriter) {
 	log.Println(e.InternalMsg)
 	resp.Header().Set("Cache-Control", "no-store")
-	http.Error(resp, e.ExternalMsg(), e.StatusCode)
+	http.Error(resp, http.StatusText(e.StatusCode), e.StatusCode)
 }

--- a/packager/util/errors_test.go
+++ b/packager/util/errors_test.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"bytes"
+	"log"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ErrorsSuite struct{
+	suite.Suite
+	logOut bytes.Buffer
+}
+
+func (this *ErrorsSuite) SetupTest() {
+	this.logOut.Reset()
+	log.SetOutput(&this.logOut)
+}
+
+func (this *ErrorsSuite) TearDownTest() {
+	log.SetOutput(os.Stderr)
+}
+
+func (this *ErrorsSuite) TestLogAndRespond() {
+	resp := httptest.NewRecorder()
+	NewHTTPError(418, "Coffee grinder is broken").LogAndRespond(resp)
+	this.Assert().Equal(418, resp.Code)
+	this.Assert().Equal("no-store", resp.Header().Get("Cache-Control"))
+	this.Assert().Equal("I'm a teapot\n", resp.Body.String())
+}
+
+func TestErrorsSuite(t *testing.T) {
+	suite.Run(t, new(ErrorsSuite))
+}

--- a/packager/util/util_test.go
+++ b/packager/util/util_test.go
@@ -1,12 +1,25 @@
 package util_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"testing"
 
 	pkgt "github.com/ampproject/amppackager/packager/testing"
 	"github.com/ampproject/amppackager/packager/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCertName(t *testing.T) {
+	assert.Equal(t, "k9GCZZIDzAt2X0b2czRv0c2omW5vgYNh6ZaIz_UNTRQ", util.CertName(pkgt.Certs[0]))
+}
+
+// ParsePrivateKey() is tested indirectly via the definition of pkgt.Key.
+func TestParsePrivateKey(t *testing.T) {
+	require.IsType(t, &ecdsa.PrivateKey{}, pkgt.Key)
+	assert.Equal(t, elliptic.P256(), pkgt.Key.(*ecdsa.PrivateKey).PublicKey.Curve)
+}
 
 func TestCanSignHttpExchanges(t *testing.T) {
 	// Leaf node has the extension.

--- a/packager/validitymap/validitymap_test.go
+++ b/packager/validitymap/validitymap_test.go
@@ -1,0 +1,24 @@
+package validitymap
+
+import (
+	"io/ioutil"
+	"testing"
+
+	pkgt "github.com/ampproject/amppackager/packager/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidityMap(t *testing.T) {
+	handler, err := New()
+	require.NoError(t, err)
+
+	resp := pkgt.Get(t, handler, "/")
+	defer resp.Body.Close()
+	assert.Equal(t, "application/cbor", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "public, max-age=604800", resp.Header.Get("Cache-Control"))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("\xA0"), body)
+}


### PR DESCRIPTION
Add tests for config.go, errors.go, util.go's CertName and ParsePrivateKey, and validitymap.go.

Addresses #17.