### PR TITLE
Add more signer tests.

### DIFF
--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -39,9 +39,6 @@ var fakePath = "/amp/secret-life-of-pine-trees.html"
 var fakeBody = []byte("They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)")
 var transformedBody = []byte("<html><head></head><body>They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)</body></html>")
 
-func boolPtr(x bool) *bool       { return &x }
-func stringPtr(x string) *string { return &x }
-
 func headerNames(headers http.Header) []string {
 	names := make([]string, len(headers))
 	i := 0

--- a/packager/signer/util_for_test.go
+++ b/packager/signer/util_for_test.go
@@ -1,0 +1,4 @@
+package signer
+
+func boolPtr(x bool) *bool       { return &x }
+func stringPtr(x string) *string { return &x }

--- a/packager/signer/validation.go
+++ b/packager/signer/validation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pquerna/cachecontrol"
 )
 
+// Converts an URL string into an URL object with an unambiguous interpretation.
 func parseURL(rawURL string, name string) (*url.URL, *util.HTTPError) {
 	if rawURL == "" {
 		return nil, util.NewHTTPError(http.StatusBadRequest, name, " URL is unspecified")
@@ -21,6 +22,11 @@ func parseURL(rawURL string, name string) (*url.URL, *util.HTTPError) {
 		return nil, util.NewHTTPError(http.StatusBadRequest, "Error parsing ", name, " URL: ", err)
 	}
 	if !ret.IsAbs() {
+		// Relative URLs don't make sense. For a fetch URL, it's not
+		// clear what from what base URL the signer should resolve it
+		// before fetching. For a sign URL, relative URLs are
+		// disallowed by the SXG spec:
+		// https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#application-signed-exchange
 		return nil, util.NewHTTPError(http.StatusBadRequest, name, " URL is relative")
 	}
 	// Evaluate "/..", by resolving the URL as a reference from itself.
@@ -29,6 +35,7 @@ func parseURL(rawURL string, name string) (*url.URL, *util.HTTPError) {
 	return ret, nil
 }
 
+// Returns true iff the given pattern matches the entire test string.
 func regexpFullMatch(pattern string, test string) bool {
 	// This is how regexp/exec_test.go turns a partial pattern into a full pattern.
 	fullRe := `\A(?:` + pattern + `)\z`
@@ -36,37 +43,58 @@ func regexpFullMatch(pattern string, test string) bool {
 	return matches
 }
 
+// Implements the URL-matching common to both fetchURLMatches and signURLMatches.
 func urlMatches(url *url.URL, pattern util.URLPattern) error {
 	if url.Opaque != "" {
+		// Opaque URLs are unfetchable, and also disallowed by the spec
+		// as sign URLs.
 		return errors.New("URL is opaque")
 	}
 	if url.User != nil {
+		// The `user:pass@` portion of a URL is not technically
+		// disallowed by the spec, but is a weird enough request that
+		// it seems wise to disable this capability by default (i.e.
+		// more likely a sign of attack than a legitimate request).
+		// Please open an issue if you have a legitimate need for this
+		// in a fetch/sign URL.
 		return errors.New("URL contains user")
 	}
+	// PathRE matches the path component of the URL, including the
+	// beginning slash.
 	if !regexpFullMatch(*pattern.PathRE, url.EscapedPath()) {
 		return errors.New("PathRE doesn't match")
 	}
+	// If any of PathExcludeRE matches, the URL does not match.
 	for _, re := range pattern.PathExcludeRE {
 		if regexpFullMatch(re, url.EscapedPath()) {
 			return errors.Errorf("PathExcludeRE matches: %s", re)
 		}
 	}
+	// QueryRE matches the query component of the URL, *not* including the
+	// beginning question mark.
 	if !regexpFullMatch(*pattern.QueryRE, url.RawQuery) {
 		return errors.New("QueryRE doesn't match")
 	}
 	return nil
 }
 
-func schemeMatches(actual string, expecteds []string) bool {
-	for _, expected := range expecteds {
-		if actual == expected {
+// True iff actualScheme is an element of expectedSchemes.
+func schemeMatches(actualScheme string, expectedSchemes []string) bool {
+	for _, expectedScheme := range expectedSchemes {
+		if actualScheme == expectedScheme {
 			return true
 		}
 	}
 	return false
 }
 
+// True iff url matches pattern, as defined by an [URLSet.Fetch] block in the
+// config file. The format of this URLPattern is validated by
+// validateFetchURLPattern in config.go.
 func fetchURLMatches(url *url.URL, pattern *util.URLPattern) error {
+	// If the fetch block is not specified, then this particular URLSet is
+	// a "sign-only" config. That is: only the sign URL should be passed to
+	// the Signer; this will be used as the fetch URL as well.
 	if pattern == nil {
 		if url == nil {
 			return nil
@@ -74,9 +102,11 @@ func fetchURLMatches(url *url.URL, pattern *util.URLPattern) error {
 			return errors.New("If URLSet.Fetch is unspecified, then so should ?fetch= be.")
 		}
 	}
+	// The fetch block may specify which schemes are allowed.
 	if !schemeMatches(url.Scheme, pattern.Scheme) {
 		return errors.New("Scheme doesn't match")
 	}
+	// The fetch block may specify either Domain or DomainRE.
 	if pattern.Domain != "" && url.Host != pattern.Domain {
 		return errors.New("Domain doesn't match")
 	}
@@ -86,16 +116,30 @@ func fetchURLMatches(url *url.URL, pattern *util.URLPattern) error {
 	return urlMatches(url, *pattern)
 }
 
+// True iff url matches pattern, as defined by an [URLSet.Sign] block in the
+// config file. The format of this URLPattern is validated by
+// validateSignURLPattern in config.go.
 func signURLMatches(url *url.URL, pattern *util.URLPattern) error {
+	// The sign block may not specify which schemes are allowed. Only HTTPS
+	// is allowed:
+	// https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#rfc.section.5.3
 	if url.Scheme != "https" {
 		return errors.New("Scheme doesn't match")
 	}
+	// The sign block may only specify Domain. DomainRE would only be
+	// useful for wildcard SXG certificates. Please open an issue if you
+	// have a valid wildcard SXG certificate and a legitimate need for
+	// this. This should be implemented with some thought into how to
+	// ensure that the sign URL matches the fetch URL.
 	if url.Host != pattern.Domain {
 		return errors.New("Domain doesn't match")
 	}
 	return urlMatches(url, *pattern)
 }
 
+// True iff the given fetchURL and signURL match the given set (as specified by
+// an [[URLSet]] block in the config file), and, if SamePath is true (default),
+// fetchURL and signURL match each other.
 func urlsMatch(fetchURL *url.URL, signURL *url.URL, set util.URLSet) error {
 	if err := fetchURLMatches(fetchURL, set.Fetch); err != nil {
 		return errors.Wrap(err, "fetch URL")
@@ -110,7 +154,11 @@ func urlsMatch(fetchURL *url.URL, signURL *url.URL, set util.URLSet) error {
 	return nil
 }
 
-// Returns parsed URLs and whether to fail on stateful headers.
+// If the given fetch and sign URLs are valid, and match at least one of the
+// urlSets (as specified by the [[URLSet]] blocks in the config file), then
+// this returns the parsed URLs as well as a bool containing the value of
+// ErrorOnStatefulHeaders for the first matching URLSet. Otherwise, returns an
+// error.
 func parseURLs(fetch string, sign string, urlSets []util.URLSet) (*url.URL, *url.URL, bool, *util.HTTPError) {
 	var fetchURL *url.URL
 	var err *util.HTTPError
@@ -138,6 +186,9 @@ func parseURLs(fetch string, sign string, urlSets []util.URLSet) (*url.URL, *url
 	return nil, nil, false, util.NewHTTPError(http.StatusBadRequest, "fetch/sign URLs do not match config")
 }
 
+// Given a request/response pair for the fetch from the packager to the backend
+// content server, validates that the response is fit for including in an AMP
+// SXG.
 func validateFetch(req *http.Request, resp *http.Response) error {
 	// Validate response is publicly-cacheable, per
 	// https://tools.ietf.org/html/draft-yasskin-http-origin-signed-responses-03#section-6.1, as referenced by

--- a/packager/signer/validation.go
+++ b/packager/signer/validation.go
@@ -1,0 +1,165 @@
+// Auxiliary functions for use by Signer.
+package signer
+
+import (
+	"mime"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/ampproject/amppackager/packager/util"
+	"github.com/pkg/errors"
+	"github.com/pquerna/cachecontrol"
+)
+
+func parseURL(rawURL string, name string) (*url.URL, *util.HTTPError) {
+	if rawURL == "" {
+		return nil, util.NewHTTPError(http.StatusBadRequest, name, " URL is unspecified")
+	}
+	ret, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, util.NewHTTPError(http.StatusBadRequest, "Error parsing ", name, " URL: ", err)
+	}
+	if !ret.IsAbs() {
+		return nil, util.NewHTTPError(http.StatusBadRequest, name, " URL is relative")
+	}
+	// Evaluate "/..", by resolving the URL as a reference from itself.
+	// This prevents malformed URLs from eluding the PathRE protections.
+	ret = ret.ResolveReference(ret)
+	return ret, nil
+}
+
+func regexpFullMatch(pattern string, test string) bool {
+	// This is how regexp/exec_test.go turns a partial pattern into a full pattern.
+	fullRe := `\A(?:` + pattern + `)\z`
+	matches, _ := regexp.MatchString(fullRe, test)
+	return matches
+}
+
+func urlMatches(url *url.URL, pattern util.URLPattern) error {
+	if url.Opaque != "" {
+		return errors.New("URL is opaque")
+	}
+	if url.User != nil {
+		return errors.New("URL contains user")
+	}
+	if !regexpFullMatch(*pattern.PathRE, url.EscapedPath()) {
+		return errors.New("PathRE doesn't match")
+	}
+	for _, re := range pattern.PathExcludeRE {
+		if regexpFullMatch(re, url.EscapedPath()) {
+			return errors.Errorf("PathExcludeRE matches: %s", re)
+		}
+	}
+	if !regexpFullMatch(*pattern.QueryRE, url.RawQuery) {
+		return errors.New("QueryRE doesn't match")
+	}
+	return nil
+}
+
+func schemeMatches(actual string, expecteds []string) bool {
+	for _, expected := range expecteds {
+		if actual == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchURLMatches(url *url.URL, pattern *util.URLPattern) error {
+	if pattern == nil {
+		if url == nil {
+			return nil
+		} else {
+			return errors.New("If URLSet.Fetch is unspecified, then so should ?fetch= be.")
+		}
+	}
+	if !schemeMatches(url.Scheme, pattern.Scheme) {
+		return errors.New("Scheme doesn't match")
+	}
+	if pattern.Domain != "" && url.Host != pattern.Domain {
+		return errors.New("Domain doesn't match")
+	}
+	if pattern.DomainRE != "" && !regexpFullMatch(pattern.DomainRE, url.Host) {
+		return errors.New("DomainRE doesn't match")
+	}
+	return urlMatches(url, *pattern)
+}
+
+func signURLMatches(url *url.URL, pattern *util.URLPattern) error {
+	if url.Scheme != "https" {
+		return errors.New("Scheme doesn't match")
+	}
+	if url.Host != pattern.Domain {
+		return errors.New("Domain doesn't match")
+	}
+	return urlMatches(url, *pattern)
+}
+
+func urlsMatch(fetchURL *url.URL, signURL *url.URL, set util.URLSet) error {
+	if err := fetchURLMatches(fetchURL, set.Fetch); err != nil {
+		return errors.Wrap(err, "fetch URL")
+	}
+	if err := signURLMatches(signURL, set.Sign); err != nil {
+		return errors.Wrap(err, "sign URL")
+	}
+	theyMatch := set.Fetch == nil || !*set.Fetch.SamePath || fetchURL.RequestURI() == signURL.RequestURI()
+	if !theyMatch {
+		return errors.New("fetch and sign paths don't match")
+	}
+	return nil
+}
+
+// Returns parsed URLs and whether to fail on stateful headers.
+func parseURLs(fetch string, sign string, urlSets []util.URLSet) (*url.URL, *url.URL, bool, *util.HTTPError) {
+	var fetchURL *url.URL
+	var err *util.HTTPError
+	if fetch != "" {
+		fetchURL, err = parseURL(fetch, "fetch")
+		if err != nil {
+			// TODO(twifkak): Use errors.Wrap() after changing return types to error.
+			return nil, nil, false, err
+		}
+	}
+	signURL, err := parseURL(sign, "sign")
+	if err != nil {
+		// TODO(twifkak): Use errors.Wrap() after changing return types to error.
+		return nil, nil, false, err
+	}
+	for _, set := range urlSets {
+		err := urlsMatch(fetchURL, signURL, set)
+		if err == nil {
+			if fetchURL == nil {
+				fetchURL = signURL
+			}
+			return fetchURL, signURL, set.Sign.ErrorOnStatefulHeaders, nil
+		}
+	}
+	return nil, nil, false, util.NewHTTPError(http.StatusBadRequest, "fetch/sign URLs do not match config")
+}
+
+func validateFetch(req *http.Request, resp *http.Response) error {
+	// Validate response is publicly-cacheable, per
+	// https://tools.ietf.org/html/draft-yasskin-http-origin-signed-responses-03#section-6.1, as referenced by
+	// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-6.
+	nonCachableReasons, _, err := cachecontrol.CachableResponse(req, resp, cachecontrol.Options{PrivateCache: false})
+	if err != nil {
+		return errors.Wrap(err, "Parsing cache headers")
+	}
+	if len(nonCachableReasons) > 0 {
+		return errors.Errorf("Non-cacheable response: %s", nonCachableReasons)
+	}
+
+	// Validate that Content-Type seems right. This doesn't validate its
+	// params (such as charset); we just want to verify we're not
+	// misinterpreting the server's intent. We override the Content-Type
+	// later for unambiguous interpretation by the browser.
+	contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return errors.Wrap(err, "Parsing Content-Type")
+	}
+	if contentType != "text/html" {
+		return errors.Errorf("Wrong Content-Type: %s", contentType)
+	}
+	return nil
+}

--- a/packager/signer/validation_test.go
+++ b/packager/signer/validation_test.go
@@ -1,0 +1,177 @@
+package signer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/ampproject/amppackager/packager/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func urlFrom(url *url.URL, err *util.HTTPError) *url.URL { return url }
+
+func errorFrom(url *url.URL, err *util.HTTPError) *util.HTTPError { return err }
+
+func urlOrDie(spec string) *url.URL {
+	url, err := url.Parse(spec)
+	if err != nil {
+		panic(err)
+	}
+	return url
+}
+
+func TestParseURL(t *testing.T) {
+	assert.EqualError(t, errorFrom(parseURL("", "sign")), "sign URL is unspecified")
+	if err := errorFrom(parseURL("abc-@#79!%^/", "sign")); assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "Error parsing sign URL")
+	}
+	assert.EqualError(t, errorFrom(parseURL("abc/def", "sign")), "sign URL is relative")
+
+	assert.Equal(t, "http://foo.com/baz", urlFrom(parseURL("http://foo.com/bar/../baz", "sign")).String())
+}
+
+func TestFetchURLMatches(t *testing.T) {
+	assert.NoError(t, fetchURLMatches(nil, nil))
+	assert.NoError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}))
+	assert.NoError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, Domain: "example.com", PathRE: stringPtr("/"), QueryRE: stringPtr("")}))
+	assert.NoError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, DomainRE: "example.*", PathRE: stringPtr("/"), QueryRE: stringPtr("")}))
+
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"), nil),
+		"If URLSet.Fetch is unspecified, then so should ?fetch= be.")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"https"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"Scheme doesn't match")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"Domain doesn't match")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com:1234/"),
+		&util.URLPattern{Scheme: []string{"http"}, Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"Domain doesn't match")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, DomainRE: "xample", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"DomainRE doesn't match")
+
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http:example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"URL is opaque")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://user@example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"URL contains user")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*")}),
+		"PathRE doesn't match")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), PathExcludeRE: []string{"/"}, QueryRE: stringPtr(".*")}),
+		"PathExcludeRE matches: /")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/?sessid=foo"),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr("")}),
+		"QueryRE doesn't match")
+}
+
+func TestSignURLMatches(t *testing.T) {
+	assert.NoError(t, signURLMatches(urlOrDie("https://example.com/"),
+		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}))
+
+	assert.EqualError(t, signURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"Scheme doesn't match")
+	assert.EqualError(t, signURLMatches(urlOrDie("https://wrongexample.com/"),
+		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		"Domain doesn't match")
+}
+
+func TestURLsMatch(t *testing.T) {
+	config := util.URLSet{
+		Fetch: &util.URLPattern{
+			Scheme: []string{"http"}, Domain: "fetch.com",
+			PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"),
+			SamePath: boolPtr(true)},
+		Sign: &util.URLPattern{
+			Domain: "sign.com",
+			PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")},
+	}
+
+	assert.NoError(t, urlsMatch(urlOrDie("http://fetch.com/"), urlOrDie("https://sign.com/"), config))
+
+	assert.EqualError(t, urlsMatch(urlOrDie("https://fetch.com/"), urlOrDie("https://sign.com/"), config),
+		"fetch URL: Scheme doesn't match")
+	assert.EqualError(t, urlsMatch(urlOrDie("http://fetch.com/"), urlOrDie("http://sign.com/"), config),
+		"sign URL: Scheme doesn't match")
+	assert.EqualError(t, urlsMatch(urlOrDie("http://fetch.com/"), urlOrDie("https://sign.com/other"), config),
+		"fetch and sign paths don't match")
+
+	*config.Fetch.SamePath = false
+	assert.NoError(t, urlsMatch(urlOrDie("http://fetch.com/"), urlOrDie("https://sign.com/other"), config))
+}
+
+func TestParseURLs(t *testing.T) {
+	if _, _, _, err := parseURLs("a%-", "b", []util.URLSet{}); assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "fetch URL")
+	}
+	if _, _, _, err := parseURLs("http://a", "b%-", []util.URLSet{}); assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "sign URL")
+	}
+
+	fetch, sign, errorOnStatefulHeaders, err := parseURLs("", "https://example.com/", []util.URLSet{
+		{Sign: &util.URLPattern{Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
+		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*")}},
+		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), ErrorOnStatefulHeaders: true}},
+		{Sign: &util.URLPattern{Domain: "badexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
+	})
+	if assert.Nil(t, err) {
+		assert.Equal(t, "https://example.com/", fetch.String())
+		assert.Equal(t, "https://example.com/", sign.String())
+		assert.True(t, errorOnStatefulHeaders)
+	}
+
+	_, _, _, err = parseURLs("", "https://example.com/", []util.URLSet{
+		{Sign: &util.URLPattern{Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
+		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*")}},
+		{Sign: &util.URLPattern{Domain: "badexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
+	})
+	if assert.NotNil(t, err) {
+		assert.EqualError(t, err, "fetch/sign URLs do not match config")
+	}
+}
+
+func TestValidateFetch(t *testing.T) {
+	req := httptest.NewRequest("", "/", nil)
+	resp := http.Response{Header:http.Header{}}
+	resp.Header.Set("Cache-Control", "max-age=ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Parsing cache headers")
+	}
+
+	resp.Header.Set("Cache-Control", "private")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Non-cacheable response")
+	}
+
+	resp.Header.Del("Cache-Control")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Non-cacheable response")
+	}
+
+	resp.Header.Set("Cache-Control", "public")
+
+	resp.Header.Set("Content-Type", "text//html")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Parsing Content-Type")
+	}
+
+	resp.Header.Set("Content-Type", "text/htmlol")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Wrong Content-Type")
+	}
+
+	resp.Header.Set("Content-Type", "TEXT/HTML")
+	assert.NoError(t, validateFetch(req, &resp))
+
+	resp.Header.Set("Content-Type", "text/html;charset=ebcdic")  // Close enough.
+	assert.NoError(t, validateFetch(req, &resp))
+}

--- a/packager/util/errors_test.go
+++ b/packager/util/errors_test.go
@@ -24,6 +24,10 @@ func (this *ErrorsSuite) TearDownTest() {
 	log.SetOutput(os.Stderr)
 }
 
+func (this *ErrorsSuite) TestError() {
+	this.Assert().Equal("Coffee grinder is broken", NewHTTPError(418, "Coffee grinder is broken").Error())
+}
+
 func (this *ErrorsSuite) TestLogAndRespond() {
 	resp := httptest.NewRecorder()
 	NewHTTPError(418, "Coffee grinder is broken").LogAndRespond(resp)


### PR DESCRIPTION
These test all the free-standing URL-validation functions as well as the
fetch-response validation function. Also changes validateFetch() to use
mime.ParseMediaType instead of a hacky string comparison.

Addresses #17.