### PR TITLE
Add nosniff headers.

### DIFF
--- a/packager/accept/accept.go
+++ b/packager/accept/accept.go
@@ -42,4 +42,3 @@ func CanSatisfy(accept string) bool {
 	}
 	return false
 }
-

--- a/packager/certcache/certcache.go
+++ b/packager/certcache/certcache.go
@@ -169,6 +169,7 @@ func (this *CertCache) ServeHTTP(resp http.ResponseWriter, req *http.Request, pa
 		}
 		resp.Header().Set("Cache-Control", "public, max-age="+strconv.Itoa(expiry))
 		resp.Header().Set("ETag", "\""+this.certName+"\"")
+		resp.Header().Set("X-Content-Type-Options", "nosniff")
 		cbor, err := this.createCertChainCBOR(ocsp)
 		if err != nil {
 			util.NewHTTPError(http.StatusInternalServerError, "Error building cert chain: ", err).LogAndRespond(resp)

--- a/packager/certcache/certcache_test.go
+++ b/packager/certcache/certcache_test.go
@@ -172,6 +172,7 @@ func (this *CertCacheSuite) DecodeCBOR(r io.Reader) map[string][]byte {
 func (this *CertCacheSuite) TestServesCertificate() {
 	resp := pkgt.GetP(this.T(), this.handler, "/amppkg/cert/"+certName, httprouter.Params{httprouter.Param{"certName", certName}})
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
+	this.Assert().Equal("nosniff", resp.Header.Get("X-Content-Type-Options"))
 	cbor := this.DecodeCBOR(resp.Body)
 	this.Assert().Contains(cbor, "cert")
 	this.Assert().Contains(cbor, "ocsp")

--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -288,6 +288,7 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 	//  2. This would require some logic for determining media type
 	//     equivalence (including parameters).
 	fetchResp.Header.Set("Content-Type", "text/html")
+	fetchResp.Header.Set("X-Content-Type-Options", "nosniff")
 
 	fetchBody, err := ioutil.ReadAll(io.LimitReader(fetchResp.Body, maxBodyLength))
 	if err != nil {
@@ -349,6 +350,7 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 	// should fetch an update (half-way between signature date & expires).
 	resp.Header().Set("Content-Type", "application/signed-exchange;v=b2")
 	resp.Header().Set("Cache-Control", "no-transform")
+	resp.Header().Set("X-Content-Type-Options", "nosniff")
 	if _, err := resp.Write(body.Bytes()); err != nil {
 		log.Println("Error writing response:", err)
 		return

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -157,7 +157,9 @@ func (this *SignerSuite) TestSimple() {
 	this.Assert().Equal(this.httpSignURL()+fakePath, exchange.RequestURI.String())
 	this.Assert().Equal(http.Header{":method": []string{"GET"}}, exchange.RequestHeaders)
 	this.Assert().Equal(200, exchange.ResponseStatus)
-	this.Assert().Equal([]string{"content-encoding", "content-length", "content-security-policy", "content-type", "date", "digest"}, headerNames(exchange.ResponseHeaders))
+	this.Assert().Equal(
+		[]string{"content-encoding", "content-length", "content-security-policy", "content-type", "date", "digest", "x-content-type-options"},
+		headerNames(exchange.ResponseHeaders))
 	this.Assert().Equal("text/html", exchange.ResponseHeaders.Get("Content-Type"))
 	this.Assert().Contains(exchange.SignatureHeaderValue, "validity-url=\""+this.httpSignURL()+"/amppkg/validity\"")
 	this.Assert().Contains(exchange.SignatureHeaderValue, "integrity=\"digest/mi-sha256-03\"")

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -150,6 +150,7 @@ func (this *SignerSuite) TestSimple() {
 			"&sign="+url.QueryEscape(this.httpSignURL()+fakePath))
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
 	this.Assert().Equal("google", resp.Header.Get("AMP-Cache-Transform"))
+	this.Assert().Equal("nosniff", resp.Header.Get("X-Content-Type-Options"))
 	this.Assert().Equal(fakePath, this.lastRequestURL)
 
 	exchange, err := signedexchange.ReadExchange(resp.Body)
@@ -161,6 +162,7 @@ func (this *SignerSuite) TestSimple() {
 		[]string{"content-encoding", "content-length", "content-security-policy", "content-type", "date", "digest", "x-content-type-options"},
 		headerNames(exchange.ResponseHeaders))
 	this.Assert().Equal("text/html", exchange.ResponseHeaders.Get("Content-Type"))
+	this.Assert().Equal("nosniff", exchange.ResponseHeaders.Get("X-Content-Type-Options"))
 	this.Assert().Contains(exchange.SignatureHeaderValue, "validity-url=\""+this.httpSignURL()+"/amppkg/validity\"")
 	this.Assert().Contains(exchange.SignatureHeaderValue, "integrity=\"digest/mi-sha256-03\"")
 	this.Assert().Contains(exchange.SignatureHeaderValue, "cert-url=\""+this.httpSignURL()+"/amppkg/cert/k9GCZZIDzAt2X0b2czRv0c2omW5vgYNh6ZaIz_UNTRQ\"")

--- a/packager/signer/validation_test.go
+++ b/packager/signer/validation_test.go
@@ -141,7 +141,7 @@ func TestParseURLs(t *testing.T) {
 
 func TestValidateFetch(t *testing.T) {
 	req := httptest.NewRequest("", "/", nil)
-	resp := http.Response{Header:http.Header{}}
+	resp := http.Response{Header: http.Header{}}
 	resp.Header.Set("Cache-Control", "max-age=ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn")
 	if err := validateFetch(req, &resp); assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Parsing cache headers")
@@ -172,6 +172,6 @@ func TestValidateFetch(t *testing.T) {
 	resp.Header.Set("Content-Type", "TEXT/HTML")
 	assert.NoError(t, validateFetch(req, &resp))
 
-	resp.Header.Set("Content-Type", "text/html;charset=ebcdic")  // Close enough.
+	resp.Header.Set("Content-Type", "text/html;charset=ebcdic") // Close enough.
 	assert.NoError(t, validateFetch(req, &resp))
 }

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -36,14 +36,14 @@ func TestMinimalValidConfig(t *testing.T) {
 	`))
 	require.NoError(t, err)
 	assert.Equal(t, Config{
-		Port: 8080,
-		CertFile: "cert.pem",
-		KeyFile: "key.pem",
+		Port:      8080,
+		CertFile:  "cert.pem",
+		KeyFile:   "key.pem",
 		OCSPCache: "/tmp/ocsp",
 		URLSet: []URLSet{{
 			Sign: &URLPattern{
-				Domain: "example.com",
-				PathRE: stringPtr(".*"),
+				Domain:  "example.com",
+				PathRE:  stringPtr(".*"),
 				QueryRE: stringPtr(".*"),
 			},
 		}},
@@ -161,10 +161,10 @@ func TestSignOverrides(t *testing.T) {
 	require.Equal(t, 1, len(config.URLSet))
 	// TODO(twifkak): Don't depend on scheme order.
 	assert.Equal(t, URLPattern{
-		Domain: "example.com",
-		PathRE: stringPtr("/amp/.*"),
-		PathExcludeRE: []string{"/amp/signin", "/amp/settings(/.*)?"},
-		QueryRE: stringPtr(""),
+		Domain:                 "example.com",
+		PathRE:                 stringPtr("/amp/.*"),
+		PathExcludeRE:          []string{"/amp/signin", "/amp/settings(/.*)?"},
+		QueryRE:                stringPtr(""),
 		ErrorOnStatefulHeaders: true,
 	}, *config.URLSet[0].Sign)
 }
@@ -212,12 +212,12 @@ func TestFetchOverrides(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(config.URLSet))
 	assert.Equal(t, URLPattern{
-		Scheme: []string{"http"},
-		DomainRE: ".*",
-		PathRE: stringPtr("/amp/.*"),
+		Scheme:        []string{"http"},
+		DomainRE:      ".*",
+		PathRE:        stringPtr("/amp/.*"),
 		PathExcludeRE: []string{"/amp/signin", "/amp/settings(/.*)?"},
-		QueryRE: stringPtr(""),
-		SamePath: boolPtr(false),
+		QueryRE:       stringPtr(""),
+		SamePath:      boolPtr(false),
 	}, *config.URLSet[0].Fetch)
 }
 

--- a/packager/util/errors_test.go
+++ b/packager/util/errors_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ErrorsSuite struct{
+type ErrorsSuite struct {
 	suite.Suite
 	logOut bytes.Buffer
 }

--- a/packager/validitymap/validitymap.go
+++ b/packager/validitymap/validitymap.go
@@ -37,5 +37,6 @@ func New() (*ValidityMap, error) {
 func (this *ValidityMap) ServeHTTP(resp http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	resp.Header().Set("Content-Type", "application/cbor")
 	resp.Header().Set("Cache-Control", "public, max-age=604800")
+	resp.Header().Set("X-Content-Type-Options", "nosniff")
 	http.ServeContent(resp, req, "", time.Time{}, bytes.NewReader(this.validityMap))
 }

--- a/packager/validitymap/validitymap_test.go
+++ b/packager/validitymap/validitymap_test.go
@@ -17,6 +17,7 @@ func TestValidityMap(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, "application/cbor", resp.Header.Get("Content-Type"))
 	assert.Equal(t, "public, max-age=604800", resp.Header.Get("Cache-Control"))
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
 
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)


### PR DESCRIPTION
Add `X-Content-Type-Options: nosniff` response header to SXG outer, SXG
inner, cert-url, and validity-url.

Fixes #138.