### PR TITLE
Don't overwrite the fetched Content-Type.

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -255,8 +255,6 @@ func (this *Signer) ServeHTTP(resp http.ResponseWriter, req *http.Request, param
 			fetchResp.Header.Del(header)
 		}
 
-		// charset=utf-8 would be redundant, as it is specified in the <meta> of a valid AMPHTML document:
-		fetchResp.Header.Set("Content-Type", "text/html")
 		fetchResp.Header.Set("Content-Security-Policy", contentSecurityPolicy)
 		fetchResp.Header.Del("Link") // Ensure there are no privacy-violating Link:rel=preload headers.
 

--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -279,15 +279,6 @@ func (this *Signer) ServeHTTP(resp http.ResponseWriter, req *http.Request, param
 
 // serveSignedExchange does the actual work of transforming, packaging and signed and writing to the response.
 func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *http.Response, signURL *url.URL) {
-	// Override the content-type of the fetch response to ensure browsers
-	// interpret the contents as HTML. The AMP Cache will validate that the
-	// payload is valid AMPHTML. Alternatively, we could reject responses
-	// with the wrong content-type, but:
-	//  1. Some existing AMP servers may not be setting the proper content
-	//     type, and may be relying on the AMP cache to rewrite it.
-	//  2. This would require some logic for determining media type
-	//     equivalence (including parameters).
-	fetchResp.Header.Set("Content-Type", "text/html")
 	fetchResp.Header.Set("X-Content-Type-Options", "nosniff")
 
 	fetchBody, err := ioutil.ReadAll(io.LimitReader(fetchResp.Body, maxBodyLength))

--- a/packager/signer/validation_test.go
+++ b/packager/signer/validation_test.go
@@ -164,14 +164,45 @@ func TestValidateFetch(t *testing.T) {
 		assert.Contains(t, err.Error(), "Parsing Content-Type")
 	}
 
+	resp.Header.Set("Content-Type", "text/html;charset=utf-8;charset=ebcdic")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Parsing Content-Type")
+	}
+
 	resp.Header.Set("Content-Type", "text/htmlol")
 	if err := validateFetch(req, &resp); assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Wrong Content-Type")
 	}
 
-	resp.Header.Set("Content-Type", "TEXT/HTML")
+	resp.Header.Set("Content-Type", "text/html;charset=ebcdic")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Wrong charset")
+	}
+
+	resp.Header.Set("Content-Type", "text/html;CHARSET=ebcdic")
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Wrong charset")
+	}
+
+	resp.Header.Set("Content-Type", `text/html; charset ="ebcdic"`)
+	if err := validateFetch(req, &resp); assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Wrong charset")
+	}
+
+	resp.Header.Set("Content-Type", "text/html")
 	assert.NoError(t, validateFetch(req, &resp))
 
-	resp.Header.Set("Content-Type", "text/html;charset=ebcdic") // Close enough.
+	// Examples from https://tools.ietf.org/html/rfc7231#section-3.1.1.1:
+
+	resp.Header.Set("Content-Type", "text/html;charset=utf-8")
+	assert.NoError(t, validateFetch(req, &resp))
+
+	resp.Header.Set("Content-Type", "text/html;charset=UTF-8")
+	assert.NoError(t, validateFetch(req, &resp))
+
+	resp.Header.Set("Content-Type", `Text/HTML;Charset="utf-8"`)
+	assert.NoError(t, validateFetch(req, &resp))
+
+	resp.Header.Set("Content-Type", `text/html; charset="utf-8"`)
 	assert.NoError(t, validateFetch(req, &resp))
 }


### PR DESCRIPTION
Doing so could have introduced bugs, as the browser may interpret the
content differently the origin server intended. Instead, the packager
more strongly validates the Content-Type it received.

Fixes #139.