### PR TITLE
Implement AMP-Cache-Transform version negotiation.

### DIFF
--- a/packager/amp_cache_transform/amp_cache_transform.go
+++ b/packager/amp_cache_transform/amp_cache_transform.go
@@ -4,16 +4,23 @@
 package amp_cache_transform
 
 import (
+	"fmt"
 	"io"
+	"log"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/ampproject/amppackager/transformer"
+	rpb "github.com/ampproject/amppackager/transformer/request"
 	"github.com/pkg/errors"
 )
 
 // https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.3
 type parameterisedIdentifier struct {
 	id string
-	// In the future, this will include params.
+	params map[string]string
 }
 
 // https://tools.ietf.org/html/rfc7230#appendix-B (OWS = "optional whitespace")
@@ -41,7 +48,9 @@ func parseParameterisedList(reader *strings.Reader) ([]parameterisedIdentifier, 
 			return nil, errors.Wrap(err, "parsing parameterised identifier")
 		}
 		items = append(items, *item)
-		// Steps 3 and 4 are swapped per https://github.com/httpwg/http-extensions/pull/667.
+		// Steps 3 and 4 are swapped per
+		// https://github.com/httpwg/http-extensions/pull/667 and
+		// https://tools.ietf.org/html/draft-thomson-postel-was-wrong-00.
 		if reader.Len() == 0 {
 			return items, nil
 		}
@@ -50,10 +59,10 @@ func parseParameterisedList(reader *strings.Reader) ([]parameterisedIdentifier, 
 		}
 		comma, err := reader.ReadByte()
 		if err != nil {
-			return nil, errors.Wrap(err, "reading comma")
+			return nil, errors.Wrap(err, "reading ','")
 		}
 		if comma != ',' {
-			return nil, errors.New("expected comma")
+			return nil, errors.New("expected ','")
 		}
 		if err := discardOWS(reader); err != nil {
 			return nil, errors.Wrap(err, "discarding OWS")
@@ -71,13 +80,102 @@ func parseParameterisedIdentifier(reader *strings.Reader) (*parameterisedIdentif
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing primary identifier")
 	}
-	// NOTE: The initial version of AMP-Cache-Transform does not support
-	// any parameters, so we don't bother to implement a parser for them.
-	// No point in distinguishing syntactic failure from semantic failure.
-	// Once we add parameters, we'll need to implement parsers for the
-	// subset item that they use. See Items here:
-	// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.4
-	return &parameterisedIdentifier{primaryID}, nil
+	// NOTE: The current version of AMP-Cache-Transform only uses
+	// string-valued parameters. Future versions of the spec may require
+	// parsing other Item types.
+	params := map[string]string{}
+	for {
+		if err := discardOWS(reader); err != nil {
+			return nil, errors.Wrap(err, "discarding OWS")
+		}
+
+		// If we've reach the end of the parameter list, exit success.
+		if reader.Len() == 0 {
+			break
+		}
+		semicolon, err := reader.ReadByte()
+		if err != nil {
+			return nil, errors.Wrap(err, "reading ';'")
+		}
+		if semicolon != ';' {
+			if err := reader.UnreadByte(); err != nil {
+				return nil, errors.Wrap(err, "unreading ';'")
+			}
+			break
+		}
+
+		// Otherwise, parse a parameter name.
+		if err := discardOWS(reader); err != nil {
+			return nil, errors.Wrap(err, "discarding OWS")
+		}
+		name, err := parseIdentifier(reader)
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing param name")
+		}
+		if _, has := params[name]; has {
+			return nil, errors.Errorf("param %q already present", name)
+		}
+		if name != "v" {
+			return nil, errors.Errorf("invalid AMP-Cache-Transform param %q", name)
+		}
+
+		// ... and a parameter value.
+		// NOTE: The current version of the AMP-Cache-Transform spec
+		// does not use any null-valued parameters. So, for now, a
+		// missing '=' is a parse failure.
+		equals, err := reader.ReadByte()
+		if err != nil {
+			return nil, errors.Wrap(err, "reading '='")
+		}
+		if equals != '=' {
+			return nil, errors.New("expected '='")
+		}
+		// NOTE: In the future, this may need to be parseItem() to
+		// support other Item types:
+		// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2.5
+		value, err := parseString(reader)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing value for param %s", name)
+		}
+
+		params[name] = value
+	}
+	return &parameterisedIdentifier{primaryID, params}, nil
+}
+
+// https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2.7
+func parseString(reader *strings.Reader) (string, error) {
+	quote, err := reader.ReadByte()
+	if err != nil {
+		return "", errors.Wrap(err, "reading '\"'")
+	}
+	if quote != '"' {
+		return "", errors.New("expected '\"'")
+	}
+	var value strings.Builder
+	for {
+		char, err := reader.ReadByte()
+		if err != nil {
+			return "", errors.Wrap(err, "reading char")
+		}
+		if char <= 0x1f || char == 0x7f {
+			return "", errors.Errorf("invalid char %d", char)
+		}
+		if char == '"' {
+			break
+		}
+		if char == '\\' {
+			char, err = reader.ReadByte()
+			if err != nil {
+				return "", errors.Wrap(err, "reading backslash-escaped char")
+			}
+			if char != '"' && char != '\\' {
+				return "", errors.Errorf("unexpected backslash-escaped char %c", char)
+			}
+		}
+		value.WriteByte(char)  // "The returned error is always nil." https://golang.org/pkg/strings/#Builder.WriteByte
+	}
+	return value.String(), nil
 }
 
 // https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-3.8
@@ -113,7 +211,9 @@ func parseIdentifier(reader *strings.Reader) (string, error) {
 		}
 		if !isSecondIdentifierChar(char) {
 			// Return to the position before the non-identifier char.
-			reader.Seek(-1, io.SeekCurrent)
+			if err := reader.UnreadByte(); err != nil {
+				return "", errors.Wrap(err, "unreading byte")
+			}
 			return output.String(), nil
 		}
 		output.WriteByte(char)
@@ -121,20 +221,73 @@ func parseIdentifier(reader *strings.Reader) (string, error) {
 	return output.String(), nil
 }
 
+// https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-transform.md#version-negotation
+var vRangeRE = regexp.MustCompile(`[ \t]*\.\.[ \t]*`)
+
+// https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-transform.md#version-negotation
+func parseVersions(v_spec string) ([]*rpb.VersionRange, error) {
+	vRanges := strings.FieldsFunc(v_spec, func(c rune) bool {
+		return c == ',' || c == ' ' || c == '\t'
+	})
+	ret := []*rpb.VersionRange{}
+	for _, vRange := range vRanges {
+		bounds := vRangeRE.Split(vRange, -1)
+		switch len(bounds) {
+		case 1:
+			version, err := strconv.ParseInt(bounds[0], 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("parsing v_range %q", vRange)
+			}
+			ret = append(ret, &rpb.VersionRange{Min: version, Max: version})
+		case 2:
+			min, err := strconv.ParseInt(bounds[0], 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("parsing v_range %q", vRange)
+			}
+			max, err := strconv.ParseInt(bounds[1], 10, 64)
+			if err != nil {
+				return nil, errors.Errorf("parsing v_range %q", vRange)
+			}
+			ret = append(ret, &rpb.VersionRange{Min: min, Max: max})
+		default:
+			return nil, errors.Errorf("parsing v_range %q", vRange)
+		}
+	}
+	// Sort descending.
+	sort.SliceStable(ret, func(i, j int) bool {
+		return ret[i].Max > ret[j].Max
+	})
+	return ret, nil
+}
+
 // If the given AMP-Cache-Transform request header value is one the packager
 // can satisfy, returns the corresponding AMP-Cache-Transform response header
-// it should send. Else, returns empty string.
-func ShouldSendSXG(header_value string) string {
+// it should send, plus the transform version it should use. Else, returns
+// empty string.
+func ShouldSendSXG(header_value string) (string, int64) {
 	reader := strings.NewReader(header_value)
 	identifiers, err := parseParameterisedList(reader)
 	if err != nil {
-		// TODO(twifkak): Debug-log err and reader.Len() bytes remaining.
-		return ""
+		log.Printf("Failed to parse AMP-Cache-Transform %q with error %v\n", header_value, err)
+		return "", 0
 	}
 	for _, identifier := range identifiers {
 		if identifier.id == "any" || identifier.id == "google" {
-			return identifier.id
+			var requested []*rpb.VersionRange
+			if v, ok := identifier.params["v"]; ok {
+				requested, err = parseVersions(v)
+				if err != nil {
+					log.Printf("Failed to parse versions from %q with error %v\n", header_value, err)
+					return "", 0
+				}
+			}
+			version, err := transformer.SelectVersion(requested)
+			if err != nil {
+				log.Printf("Failed to select version from %q with error %v\n", header_value, err)
+				continue
+			}
+			return fmt.Sprintf(`%s;v="%d"`, identifier.id, version), version
 		}
 	}
-	return ""
+	return "", 0
 }

--- a/packager/amp_cache_transform/amp_cache_transform_test.go
+++ b/packager/amp_cache_transform/amp_cache_transform_test.go
@@ -3,30 +3,52 @@ package amp_cache_transform
 import (
 	"testing"
 
+	"github.com/ampproject/amppackager/transformer"
+	rpb "github.com/ampproject/amppackager/transformer/request"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestShouldSendSXG(t *testing.T) {
-	assert.Equal(t, "any", ShouldSendSXG("any"))
-	assert.Equal(t, "any", ShouldSendSXG("foobar, any"))
-	assert.Equal(t, "any", ShouldSendSXG("any, google"))
-	assert.Equal(t, "google", ShouldSendSXG("google"))
-	assert.Equal(t, "google", ShouldSendSXG("google, any"))
-	assert.Equal(t, "google", ShouldSendSXG("google, foobar"))
-	assert.Equal(t, "google", ShouldSendSXG("google,foobar"))
-	assert.Equal(t, "google", ShouldSendSXG("google,\tfoobar"))
-	assert.Equal(t, "google", ShouldSendSXG("google ,foobar"))
-	assert.Equal(t, "google", ShouldSendSXG("google, a*b-c_d/e"))
+func header(header string, version int64) string {
+	return header
+}
 
-	assert.Equal(t, "", ShouldSendSXG(""))
-	assert.Equal(t, "", ShouldSendSXG(" any"))
-	assert.Equal(t, "", ShouldSendSXG("any "))
-	assert.Equal(t, "", ShouldSendSXG("foobar"))
-	assert.Equal(t, "", ShouldSendSXG("foobar, baz"))
-	assert.Equal(t, "", ShouldSendSXG("googleany"))
-	assert.Equal(t, "", ShouldSendSXG("google;any"))
-	assert.Equal(t, "", ShouldSendSXG("google;v=1"))
-	assert.Equal(t, "", ShouldSendSXG("google,123"))
-	assert.Equal(t, "", ShouldSendSXG("google, eh!"))
-	assert.Equal(t, "", ShouldSendSXG("ABC,google"))
+func TestShouldSendSXG(t *testing.T) {
+	orig := transformer.SupportedVersions
+	defer func() { transformer.SupportedVersions = orig }()
+	transformer.SupportedVersions = []*rpb.VersionRange{{Max: 1, Min: 1}}
+
+	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG("any")))
+	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG("foobar, any")))
+	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG("any, google")))
+	// Technically this is a false positive -- trailing OWS is not allowed
+	// by the spec. (This is occurring because the comma parsing code
+	// doesn't fail if it finds OWS and no comma.) That said... meh. Close
+	// enough:
+	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG("any ")))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG("google")))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG("google, any")))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG("google, foobar")))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG("google,foobar")))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG("google,\tfoobar")))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG("google ,foobar")))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG("google, a*b-c_d/e")))
+
+	assert.Equal(t, "", header(ShouldSendSXG("")))
+	assert.Equal(t, "", header(ShouldSendSXG(" any")))
+	assert.Equal(t, "", header(ShouldSendSXG("foobar")))
+	assert.Equal(t, "", header(ShouldSendSXG("foobar, baz")))
+	assert.Equal(t, "", header(ShouldSendSXG("googleany")))
+	assert.Equal(t, "", header(ShouldSendSXG("google;any")))
+	assert.Equal(t, "", header(ShouldSendSXG("google;v=1")))
+	assert.Equal(t, "", header(ShouldSendSXG("google,123")))
+	assert.Equal(t, "", header(ShouldSendSXG("google, eh!")))
+	assert.Equal(t, "", header(ShouldSendSXG("ABC,google")))
+
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="1"`)))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="1..2"`)))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="1,2..3,5"`)))
+
+	assert.Equal(t, "", header(ShouldSendSXG(`google;v="2"`)))
+	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG(`google;v="2",any`)))
+	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="2",google`)))
 }

--- a/packager/amp_cache_transform/amp_cache_transform_test.go
+++ b/packager/amp_cache_transform/amp_cache_transform_test.go
@@ -58,10 +58,10 @@ func TestShouldSendSXG(t *testing.T) {
 	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="1 "`)))
 
 	// Version spec failure.
-	assert.Equal(t, "", header(ShouldSendSXG(`google,v="1"`)))
-	assert.Equal(t, "", header(ShouldSendSXG(`google;v ="1"`)))
-	assert.Equal(t, "", header(ShouldSendSXG(`google;v= "1"`)))
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v="2"`)))
+	assert.Equal(t, "", header(ShouldSendSXG(`google,v="1",any`)))
+	assert.Equal(t, "", header(ShouldSendSXG(`google;v ="1",any`)))
+	assert.Equal(t, "", header(ShouldSendSXG(`google;v= "1",any`)))
 	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG(`google;v="2",any`)))
 	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG(`google;v="2..frog",any`)))
 	assert.Equal(t, `any;v="1"`, header(ShouldSendSXG(`google;v="-1..1",any`)))

--- a/packager/amp_cache_transform/amp_cache_transform_test.go
+++ b/packager/amp_cache_transform/amp_cache_transform_test.go
@@ -40,7 +40,6 @@ func TestShouldSendSXG(t *testing.T) {
 	assert.Equal(t, "", header(ShouldSendSXG("foobar, baz")))
 	assert.Equal(t, "", header(ShouldSendSXG("googleany")))
 	assert.Equal(t, "", header(ShouldSendSXG("google;any")))
-	assert.Equal(t, "", header(ShouldSendSXG("google;v=1")))
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v="1,any`)))
 	assert.Equal(t, "", header(ShouldSendSXG("google,123")))
 	assert.Equal(t, "", header(ShouldSendSXG("google, eh!")))
@@ -59,6 +58,7 @@ func TestShouldSendSXG(t *testing.T) {
 
 	// Version spec failure.
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v="2"`)))
+	assert.Equal(t, "", header(ShouldSendSXG("google;v=1,any")))
 	assert.Equal(t, "", header(ShouldSendSXG(`google,v="1",any`)))
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v ="1",any`)))
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v= "1",any`)))

--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -224,14 +224,24 @@ func (this *Signer) ServeHTTP(resp http.ResponseWriter, req *http.Request, param
 		proxy(resp, fetchResp, nil)
 		return
 	}
+	var transformVersion int64
 	if this.requireHeaders {
-		act := amp_cache_transform.ShouldSendSXG(req.Header.Get("AMP-Cache-Transform"))
+		header_value := req.Header.Get("AMP-Cache-Transform")
+		var act string
+		act, transformVersion = amp_cache_transform.ShouldSendSXG(header_value)
 		if act == "" {
-			log.Println("Not packaging because AMP-Cache-Transform request header is missing.")
+			log.Println("Not packaging because AMP-Cache-Transform request header is invalid:", header_value)
 			proxy(resp, fetchResp, nil)
 			return
 		}
 		resp.Header().Set("AMP-Cache-Transform", act)
+	} else {
+		var err error
+		transformVersion, err = transformer.SelectVersion(nil)
+		if err != nil {
+			log.Println("Not packaging because of internal SelectVersion error:", err)
+			proxy(resp, fetchResp, nil)
+		}
 	}
 	if this.requireHeaders && !accept.CanSatisfy(req.Header.Get("Accept")) {
 		log.Printf("Not packaging because Accept request header lacks application/signed-exchange;v=%s.\n", accept.AcceptedSxgVersion)
@@ -259,7 +269,7 @@ func (this *Signer) ServeHTTP(resp http.ResponseWriter, req *http.Request, param
 		fetchResp.Header.Set("Content-Security-Policy", contentSecurityPolicy)
 		fetchResp.Header.Del("Link") // Ensure there are no privacy-violating Link:rel=preload headers.
 
-		this.serveSignedExchange(resp, fetchResp, signURL)
+		this.serveSignedExchange(resp, fetchResp, signURL, transformVersion)
 
 	case 304:
 		// If fetchURL returns a 304, then also return a 304 with appropriate headers.
@@ -298,7 +308,7 @@ func formatLinkHeader(preloads []*rpb.Metadata_Preload) (string, error) {
 }
 
 // serveSignedExchange does the actual work of transforming, packaging and signed and writing to the response.
-func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *http.Response, signURL *url.URL) {
+func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *http.Response, signURL *url.URL, transformVersion int64) {
 	fetchResp.Header.Set("X-Content-Type-Options", "nosniff")
 
 	// After this, fetchResp.Body is consumed, and attempts to read or proxy it will result in an empty body.
@@ -310,6 +320,7 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 
 	// Perform local transformations.
 	r := getTransformerRequest(this.rtvCache, string(fetchBody), signURL.String())
+	r.Version = transformVersion
 	transformed, metadata, err := transformer.Process(r)
 	if err != nil {
 		log.Println("Not packaging due to transformer error:", err)

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -17,6 +17,7 @@ package signer
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +30,7 @@ import (
 	"github.com/ampproject/amppackager/packager/rtv"
 	pkgt "github.com/ampproject/amppackager/packager/testing"
 	"github.com/ampproject/amppackager/packager/util"
+	"github.com/ampproject/amppackager/transformer"
 	rpb "github.com/ampproject/amppackager/transformer/request"
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/suite"
@@ -150,7 +152,7 @@ func (this *SignerSuite) TestSimple() {
 		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath)+
 			"&sign="+url.QueryEscape(this.httpSignURL()+fakePath))
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
-	this.Assert().Equal("google", resp.Header.Get("AMP-Cache-Transform"))
+	this.Assert().Equal(fmt.Sprintf(`google;v="%d"`, transformer.SupportedVersions[0].Max), resp.Header.Get("AMP-Cache-Transform"))
 	this.Assert().Equal("nosniff", resp.Header.Get("X-Content-Type-Options"))
 	this.Assert().Equal(fakePath, this.lastRequestURL)
 


### PR DESCRIPTION
Parse v parameters per the spec, and use the new
transform.SelectVersion() function to perform proactive version
negotiation given the request.

Fixes #29.