### PR TITLE
Percent-escape URL-invalid query chars in Link.

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -295,6 +295,10 @@ func formatLinkHeader(preloads []*rpb.Metadata_Preload) (string, error) {
 		if err != nil {
 			return "", errors.Wrapf(err, "Invalid preload URL: %q\n", preload.Url)
 		}
+		// Percent-escape any characters in the query that aren't valid
+		// URL characters (but don't escape '=' or '&').
+		u.RawQuery = url.PathEscape(u.RawQuery)
+
 		if preload.As == "" {
 			return "", errors.Errorf("Missing `as` attribute for preload URL: %q\n", preload.Url)
 		}

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -293,14 +293,14 @@ func (this *SignerSuite) TestEscapesLinkHeaders() {
 		// However, it would be nice to limit the impact that could be
 		// caused by transformation of an invalid AMP, e.g. on a
 		// same-origin impression.
-		resp.Write([]byte(`<html amp><head><script src="https://foo.com/a,b>c">`))
+		resp.Write([]byte(`<html amp><head><script src="https://foo.com/a,b>c?d>e|f">`))
 	}
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
 
 	exchange, err := signedexchange.ReadExchange(resp.Body)
 	this.Require().NoError(err)
-	this.Assert().Equal("<https://foo.com/a,b%3Ec>;rel=preload;as=script", exchange.ResponseHeaders.Get("Link"))
+	this.Assert().Equal("<https://foo.com/a,b%3Ec?d%3Ee%7Cf>;rel=preload;as=script", exchange.ResponseHeaders.Get("Link"))
 }
 
 func (this *SignerSuite) TestErrorNoCache() {


### PR DESCRIPTION
This fixes preloads for fonts.googleapis.com, which include `|` in their
query component.

It might not be exactly correct, but will fix some known issues. I'll file a bug to follow up.