### PR TITLE
Disallow query strings by default.

### DIFF
--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -101,9 +101,9 @@ OCSPCache = '/tmp/amppkg-ocsp'
     # PathExcludeRE = []
 
     # A full-match regexp on the query portion of the URL, excluding the initial
-    # "?". Defaults to ".*". The below example disallows non-empty query strings
-    # (though a single "?" is allowed).
-    # QueryRE = ""
+    # "?". Defaults to "" (though a single "?" is allowed). The below example
+    # allows non-empty query strings.
+    # QueryRE = ".*"
 
     # The fragment portion of the URL (i.e. the '#' and everything after) must
     # be empty. There is no way to configure this.

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -48,6 +48,7 @@ type URLPattern struct {
 	SamePath               *bool
 }
 
+var emptyRegexp = ""
 var dotStarRegexp = ".*"
 
 // Also sets defaults.
@@ -63,7 +64,7 @@ func validateURLPattern(pattern *URLPattern) error {
 		}
 	}
 	if pattern.QueryRE == nil {
-		pattern.QueryRE = &dotStarRegexp
+		pattern.QueryRE = &emptyRegexp
 	} else if _, err := regexp.Compile(*pattern.QueryRE); err != nil {
 		return errors.New("QueryRE must be a valid regexp")
 	}

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -44,7 +44,7 @@ func TestMinimalValidConfig(t *testing.T) {
 			Sign: &URLPattern{
 				Domain:  "example.com",
 				PathRE:  stringPtr(".*"),
-				QueryRE: stringPtr(".*"),
+				QueryRE: stringPtr(""),
 			},
 		}},
 	}, *config)
@@ -188,7 +188,7 @@ func TestFetchDefaults(t *testing.T) {
 	assert.Equal(t, "example.com", fetch.Domain)
 	assert.Equal(t, stringPtr(".*"), fetch.PathRE)
 	assert.Nil(t, fetch.PathExcludeRE)
-	assert.Equal(t, stringPtr(".*"), fetch.QueryRE)
+	assert.Equal(t, stringPtr(""), fetch.QueryRE)
 	assert.Equal(t, false, fetch.ErrorOnStatefulHeaders)
 	assert.Equal(t, boolPtr(true), fetch.SamePath)
 }


### PR DESCRIPTION
This is a change to the default behavior of QueryRE in the config file;
users needing to sign URLs with query parameters will need to update
their configs.

Fixes #208.