### PR TITLE
Unify (and fix) comma-splitting logic.

### DIFF
--- a/packager/accept/accept.go
+++ b/packager/accept/accept.go
@@ -2,9 +2,9 @@ package accept
 
 import (
 	"mime"
-	"regexp"
 
 	"github.com/WICG/webpackage/go/signedexchange/version"
+	"github.com/ampproject/amppackager/packager/util"
 )
 
 // The SXG version that packager can produce. In the future, it may need to be
@@ -18,25 +18,19 @@ const SxgContentType = "application/signed-exchange;v=" + AcceptedSxgVersion
 // signedexchange library.
 var SxgVersion = version.Version1b2
 
-// A comma, as would appear in an Accept header. Comma-separation is defined
-// in https://tools.ietf.org/html/rfc7230#section-7, with OWS defined in
-// https://tools.ietf.org/html/rfc7230#appendix-B.
-//
-// There is an edge case on which this fails:
-//   Accept: application/signed-exchange;junk="some,thing";v=b2
-// However, in practice, browsers don't send media types with quoted
-// commas in them:
-//   https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
-// So we'll live with this deficiency for the sake of not forking
-// mime.ParseMediaType.
-var comma *regexp.Regexp = regexp.MustCompile(`[ \t]*,[ \t]*`)
-
 // True if the given Accept header is one that the packager can satisfy. It
 // must contain application/signed-exchange;v=$V so that the packager knows
 // whether or not it can supply the correct version. "" and "*/*" are not
 // satisfiable, for this reason.
 func CanSatisfy(accept string) bool {
-	types := comma.Split(accept, -1)
+	// There is an edge case on which this comma-splitting fails:
+	//   Accept: application/signed-exchange;junk="some,thing";v=b2
+	// However, in practice, browsers don't send media types with quoted
+	// commas in them:
+	//   https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values
+	// So we'll live with this deficiency for the sake of not forking
+	// mime.ParseMediaType.
+	types := util.Comma.Split(accept, -1)
 	for _, mediaRange := range types {
 		mediatype, params, err := mime.ParseMediaType(mediaRange)
 		if err == nil && mediatype == "application/signed-exchange" && params["v"] == AcceptedSxgVersion {

--- a/packager/amp_cache_transform/amp_cache_transform.go
+++ b/packager/amp_cache_transform/amp_cache_transform.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ampproject/amppackager/packager/util"
 	"github.com/ampproject/amppackager/transformer"
 	rpb "github.com/ampproject/amppackager/transformer/request"
 	"github.com/pkg/errors"
@@ -227,10 +228,8 @@ func parseIdentifier(reader *strings.Reader) (string, error) {
 var vRangeRE = regexp.MustCompile(`[ \t]*\.\.[ \t]*`)
 
 // https://github.com/ampproject/amphtml/blob/master/spec/amp-cache-transform.md#version-negotation
-func parseVersions(v_spec string) ([]*rpb.VersionRange, error) {
-	vRanges := strings.FieldsFunc(v_spec, func(c rune) bool {
-		return c == ',' || c == ' ' || c == '\t'
-	})
+func parseVersions(vSpec string) ([]*rpb.VersionRange, error) {
+	vRanges := util.Comma.Split(vSpec, -1)
 	ret := []*rpb.VersionRange{}
 	for _, vRange := range vRanges {
 		bounds := vRangeRE.Split(vRange, -1)

--- a/packager/amp_cache_transform/amp_cache_transform_test.go
+++ b/packager/amp_cache_transform/amp_cache_transform_test.go
@@ -54,11 +54,6 @@ func TestShouldSendSXG(t *testing.T) {
 	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="1..2"`)))
 	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="1,2..3,5"`)))
 	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google ; v="1"`)))
-	// Technically these two are false positives -- surrounding whitespace
-	// is not allowed by the spec. This is a consequence of using
-	// strings.FieldsFunc. Meh, close enough:
-	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v=" 1"`)))
-	assert.Equal(t, `google;v="1"`, header(ShouldSendSXG(`google;v="1 "`)))
 
 	// Version spec parse failure.
 	assert.Equal(t, "", header(ShouldSendSXG(`google;`)))
@@ -67,6 +62,9 @@ func TestShouldSendSXG(t *testing.T) {
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v=`)))
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v="`)))
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v="\`)))
+	assert.Equal(t, "", header(ShouldSendSXG(`google;v=" 1"`)))
+	assert.Equal(t, "", header(ShouldSendSXG(`google;v="1 "`)))
+	assert.Equal(t, "", header(ShouldSendSXG(`google;v="1 2"`)))
 	assert.Equal(t, "", header(ShouldSendSXG("google;v=1,any")))
 	assert.Equal(t, "", header(ShouldSendSXG(`google,v="1",any`)))
 	assert.Equal(t, "", header(ShouldSendSXG(`google;v ="1",any`)))

--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -90,11 +90,6 @@ var statusNotModifiedHeaders = map[string]bool{
 	"Vary":             true,
 }
 
-// A comma, as would appear in a Connection header. Comma-separation is defined
-// in https://tools.ietf.org/html/rfc7230#section-7, with OWS defined in
-// https://tools.ietf.org/html/rfc7230#appendix-B.
-var comma *regexp.Regexp = regexp.MustCompile(`[ \t]*,[ \t]*`)
-
 // MICE requires the sender process its payload in reverse order
 // (https://tools.ietf.org/html/draft-thomson-http-mice-03#section-2.1).
 // In an HTTP reverse proxy, this could be done using range requests, but would
@@ -135,7 +130,7 @@ var legacyHeaders = []string{"Connection", "Keep-Alive", "Proxy-Authenticate", "
 func removeHopByHopHeaders(resp *http.Response) {
 	if connections, ok := resp.Header[http.CanonicalHeaderKey("Connection")]; ok {
 		for _, connection := range connections {
-			headerNames := comma.Split(connection, -1)
+			headerNames := util.Comma.Split(connection, -1)
 			for _, headerName := range headerNames {
 				resp.Header.Del(headerName)
 			}

--- a/packager/util/http.go
+++ b/packager/util/http.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"regexp"
+)
+
+// A comma, as defined in https://tools.ietf.org/html/rfc7230#section-7, with
+// OWS defined in https://tools.ietf.org/html/rfc7230#appendix-B. This is
+// commonly used as a separator in header field value definitions.
+var Comma *regexp.Regexp = regexp.MustCompile(`[ \t]*,[ \t]*`)


### PR DESCRIPTION
Introduce a new util function to do typical comma-splitting, as defined
by RFC7230. This fixes a few bugs in the AMP-Cache-Transform parser,
which had a flawed comma parser.

Fixes #196.