### PR TITLE
Add a 2000-char URL length limit by default.

### DIFF
--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -84,8 +84,18 @@ OCSPCache = '/tmp/amppkg-ocsp'
     # certificate must cover this domain.
     Domain = "amppackageexample.com"
 
-    # A full-match regexp on the path (not including the ?query).
-    # Defaults to ".*". The below example allows paths starting with /world/.
+    # A full-match regexp on the path (not including the ?query). Defaults to
+    # ".{,1000}" -- that is, any path <= 1000 chars long.
+    #
+    # The length limit is to mitigate the risk of a content-sniffing attack
+    # (per https://github.com/WICG/webpackage/pull/348) against downstream
+    # servers that serve 200 responses regardless of some of the path
+    # components (e.g. looking up by id and not validating the slug in the
+    # requested URL). If your server only serves 200 responses on a limited set
+    # of valid URLs, and some of those URLs are >1000 chars, then it's safe to
+    # modify this default.
+    #
+    # The below example allows paths starting with /world/.
     # PathRE = "/world/.*"
 
     # A list of full-match regexps, carving out exclusions to the above PathRE.

--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -85,14 +85,14 @@ OCSPCache = '/tmp/amppkg-ocsp'
     Domain = "amppackageexample.com"
 
     # A full-match regexp on the path (not including the ?query). Defaults to
-    # ".{,1000}" -- that is, any path <= 1000 chars long.
+    # ".{,2000}" -- that is, any path <= 2000 chars long.
     #
     # The length limit is to mitigate the risk of a content-sniffing attack
     # (per https://github.com/WICG/webpackage/pull/348) against downstream
     # servers that serve 200 responses regardless of some of the path
     # components (e.g. looking up by id and not validating the slug in the
     # requested URL). If your server only serves 200 responses on a limited set
-    # of valid URLs, and some of those URLs are >1000 chars, then it's safe to
+    # of valid URLs, and some of those URLs are >2000 chars, then it's safe to
     # modify this default.
     #
     # The below example allows paths starting with /world/.

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -49,7 +49,7 @@ type URLPattern struct {
 }
 
 var emptyRegexp = ""
-var defaultPathRegexp = ".{,1000}"
+var defaultPathRegexp = ".{,2000}"
 
 // Also sets defaults.
 func validateURLPattern(pattern *URLPattern) error {

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -49,12 +49,12 @@ type URLPattern struct {
 }
 
 var emptyRegexp = ""
-var dotStarRegexp = ".*"
+var defaultPathRegexp = ".{,1000}"
 
 // Also sets defaults.
 func validateURLPattern(pattern *URLPattern) error {
 	if pattern.PathRE == nil {
-		pattern.PathRE = &dotStarRegexp
+		pattern.PathRE = &defaultPathRegexp
 	} else if _, err := regexp.Compile(*pattern.PathRE); err != nil {
 		return errors.New("PathRE must be a valid regexp")
 	}

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -43,7 +43,7 @@ func TestMinimalValidConfig(t *testing.T) {
 		URLSet: []URLSet{{
 			Sign: &URLPattern{
 				Domain:  "example.com",
-				PathRE:  stringPtr(".*"),
+				PathRE:  stringPtr(".{,1000}"),
 				QueryRE: stringPtr(""),
 			},
 		}},

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -186,7 +186,7 @@ func TestFetchDefaults(t *testing.T) {
 	assert.ElementsMatch(t, []string{"http", "https"}, fetch.Scheme)
 	assert.Equal(t, "", fetch.DomainRE)
 	assert.Equal(t, "example.com", fetch.Domain)
-	assert.Equal(t, stringPtr(".*"), fetch.PathRE)
+	assert.Equal(t, stringPtr(".{,2000}"), fetch.PathRE)
 	assert.Nil(t, fetch.PathExcludeRE)
 	assert.Equal(t, stringPtr(""), fetch.QueryRE)
 	assert.Equal(t, false, fetch.ErrorOnStatefulHeaders)

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -43,7 +43,7 @@ func TestMinimalValidConfig(t *testing.T) {
 		URLSet: []URLSet{{
 			Sign: &URLPattern{
 				Domain:  "example.com",
-				PathRE:  stringPtr(".{,1000}"),
+				PathRE:  stringPtr(".{,2000}"),
 				QueryRE: stringPtr(""),
 			},
 		}},


### PR DESCRIPTION
This is to mitigate the content-sniffing risk outlined in
WICG/webpackage#348.

cc @molnarg 