### PR TITLE
Switch transform_wasm to read internal testfiles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /main
 /fuzz_httpreq/fuzz.zip
 /fuzz_httpresp/fuzz.zip
+/transform.wasm

--- a/cmd/transform_wasm/main.go
+++ b/cmd/transform_wasm/main.go
@@ -30,7 +30,8 @@ func transform(args []js.Value /* url, html, cb(htmlout) */) {
 	r := &rpb.Request{Html: args[1].String(), DocumentUrl: args[0].String(), Config: rpb.Request_DEFAULT}
 	o, _, err := t.Process(r)
 	if err != nil {
-		panic(err)
+		js.Global().Get("console").Call("log", err.Error())  // println doesn't go anywhere.
+		o = ""  // Need to invoke the done callback with something well-defined.
 	}
 	args[2].Invoke(o + "\n")
 }
@@ -40,6 +41,7 @@ func main() {
 	defer cb.Release()
 	done := make(chan struct{})
 	donecb := js.NewCallback(func(args []js.Value) { done <- struct{}{} })
+	defer donecb.Release()
 	js.Global().Get("begin").Invoke(cb, donecb)
 	<-done
 }

--- a/cmd/transform_wasm/main.js
+++ b/cmd/transform_wasm/main.js
@@ -12,43 +12,82 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Bootstrapper for transform_wasm. Transforms all html files in
-// ${TESTDIR:-/tmp/amps}.
+// Bootstrapper for transform_wasm. Transforms all html in the test files
+// specified on the commandline.
 //
 // To use:
 //   GOOS=js GOARCH=wasm go build -o transform.wasm ./cmd/transform_wasm/ &&
-//   node --max-old-space-size=4096 cmd/transform_wasm/main.js transform.wasm
+//   node --max-old-space-size=7000 cmd/transform_wasm/main.js transform.wasm \
+//     path/to/test/files*
 
 // TODO(twifkak): Investigate slowdown over time.
 // TODO(twifkak): Investigate memory usage growth.
 
 const assert = require('assert');
+const fs = require('fs');
 const { join } = require('path');
 const { spawnSync } = require('child_process');
 
+// Polyfill to flatten an array by one level.
+const flat = [].flat ? (arr) => arr.flat() : (arr) => [].concat(...arr);
+
 function listRecursive(dir) {
-  return [].concat(...fs.readdirSync(dir, {withFileTypes: true}).map((dirent) =>
+  return flat(fs.readdirSync(dir, {withFileTypes: true}).map((dirent) =>
       dirent.isDirectory() ? listRecursive(join(dir, dirent.name)) : join(dir, dirent.name)));
 }
 
+// Take everything after "transform.wasm" and remove it from argv so that
+// wasm_exec.js doesn't pass it to the Go binary.
+const testFiles = process.argv.splice(3);
+
+const markerText = '>>>>>>>>>> Test Case <<<<<<<<<<\n';
+
+async function readTestFiles() {
+  // Read all the HTML test cases into memory.
+  let htmls = [];
+  for (const testFile of testFiles) {
+    console.log(`Opening ${testFile}...`);
+    let pending = '';
+    for await (const chunk of fs.createReadStream(testFile, {encoding: 'utf8'})) {
+      pending += chunk;
+      let pastLastMarker = 0; // Position just past the previously found marker.
+      let marker; // Position of the current marker.
+      while (marker = pending.indexOf(markerText, pastLastMarker), marker !== -1) {
+        if (marker > pastLastMarker)
+          htmls.push(pending.substring(pastLastMarker, marker));
+        pastLastMarker = marker + markerText.length;
+      }
+      pending = pending.substring(pastLastMarker);
+    }
+    htmls.push(pending);
+  }
+
+  // Parse the URL from each test case.
+  htmls.forEach((html, i) => {
+    let newline = html.indexOf('\n');
+    htmls[i] = [html.substring(0, newline), html.substring(newline + 1)];
+  });
+
+  console.log('Pushed all %d tests.', htmls.length);
+
+  return htmls;
+}
+
 global.begin = async function(transform, done) {
-  const baseDir = process.env.TESTDIR || '/tmp/amps';
-  const htmlPaths = listRecursive(baseDir).filter((file) => file.endsWith('.html'));
   let num = 0;
-  let outs = htmlPaths.map((path) =>
-    new Promise((resolve) => {
-      const html = fs.readFileSync(path);
-      transform('https://example.com/', html, (amphtml) => {
+  let outs = (await readTestFiles()).map(([url, html]) =>
+    new Promise((resolve) =>
+      transform(url, html, (amphtml) => {
           if (++num % 100 == 0) console.log('num = ', num);
-          assert(amphtml.length > 1000);  // "Minimum valid AMP" is larger than 1K.
+          // Minimum valid AMP is larger than 1K.
+          if (amphtml.length < 1000) console.log('URL ', url, ' output is invalid: ', amphtml);
           resolve(amphtml);
-      });
-    }));
-  console.log('Pushed all %d thunks.', htmlPaths.length);
+      })));
+  console.log('Pushed all %d thunks.', outs.length);
   const start = process.hrtime.bigint();
   await Promise.all(outs);
   const total = process.hrtime.bigint() - start;
-  console.log(`Took ${total} nanoseconds, or ${Number(total) / htmlPaths.length / 1000000} millis per doc.`);
+  console.log(`Took ${total} nanoseconds, or ${Number(total) / outs.length / 1000000} millis per doc.`);
   done();
 }
 


### PR DESCRIPTION
This makes it easier to run against our regression test sets. As a
downside, it increases memory usage considerably. Perhaps I place too
much faith in the garbage collector.

Also, make transformation errors non-fatal. This helped debug some
issues with the testfile parser initially.