### PR TITLE
Improve TypedArray speed, memory usage, and API.

### DIFF
--- a/cmd/transform_wasm/main_go1.11.go
+++ b/cmd/transform_wasm/main_go1.11.go
@@ -20,50 +20,93 @@ Binary wrapper for the transformer lib, to be run via main.js.
 package main
 
 import (
+	"bytes"
+	"encoding/binary"
 	"syscall/js"
 
 	rpb "github.com/ampproject/amppackager/transformer/request"
 	t "github.com/ampproject/amppackager/transformer"
+	"github.com/pkg/errors"
 )
 
-var maxLen = 4*1024*1024
+// Max length of a URL. Based on the de facto limit per
+// https://stackoverflow.com/a/417184.
+var urlInMaxLen uint32 = 2000
+// Max length of an AMP document.
+var htmlInMaxLen uint32 = 4*1024*1024
+// Max length of the transformed AMP. Arbitrarily larger just in case. I
+// suspect the transforms may increase document size in some cases (doubtful
+// ever doubling it, but I'd rather overallocate a few MBs than fail
+// transformation).
+var htmlOutMaxLen uint32 = htmlInMaxLen * 2
 
-var urlIn = make([]byte, 2000)
-var htmlIn = make([]byte, maxLen)
-var htmlOut = make([]byte, maxLen)
+// Buffers to be used for a uint32 length prefix followed by a
+// non-NUL-terminated string.
+var urlIn = make([]byte, urlInMaxLen + 4)
+var htmlIn = make([]byte, htmlInMaxLen + 4)
+var htmlOut = make([]byte, htmlOutMaxLen + 4)
 
-// Useful since println() doesn't go anywhere.
-func consoleLog(msg string) {
-	js.Global().Get("console").Call("log", msg)
+
+func bufferToString(buf []byte) (string, error) {
+	var length uint32
+	if err := binary.Read(bytes.NewReader(buf), binary.BigEndian, &length); err != nil {
+		return "", errors.Wrap(err, "decoding length")
+	}
+	return string(buf[4:length+4]), nil
 }
 
-// Transforms the doc specified in url/htmlIn into htmlOut. Args:
-//   urlLen: int
-//   htmlLen: int
-//   done: function(htmlOutLen: int)
+func errorOut(msg string) {
+	js.Global().Get("console").Call("log", msg)  // Useful since println() doesn't go anywhere.
+	copy(htmlOut, []byte{0, 0, 0, 0})  // Set htmlOut to empty string.
+}
+
+// Transforms the doc specified in url/htmlIn into htmlOut. Takes a nullary
+// done callback as its only argument.
 func transform(args []js.Value) {
-	r := &rpb.Request{DocumentUrl: string(urlIn[:args[0].Int()]), Html: string(htmlIn[:args[1].Int()]), Config: rpb.Request_DEFAULT}
-	o, _, err := t.Process(r)
+	var url, html string
+	var err error
+	if url, err = bufferToString(urlIn); err != nil {
+		errorOut(err.Error())
+		return
+	}
+	if html, err = bufferToString(htmlIn); err != nil {
+		errorOut(err.Error())
+		return
+	}
+
+	r := &rpb.Request{DocumentUrl: url, Html: html, Config: rpb.Request_DEFAULT}
+	out, _, err := t.Process(r)
 	if err != nil {
-		consoleLog(err.Error())
-		o = ""  // Need to invoke the done callback with something well-defined.
+		errorOut(err.Error())
+		return
 	}
-	if len(o) > maxLen {
-		consoleLog("transformed doc too big (" + string(len(o)) + ") for url: " + string(urlIn))
-		o = ""  // Need to invoke the done callback with something well-defined.
+	if uint64(len(out)) > uint64(htmlOutMaxLen) {
+		errorOut("transformed doc too big (" + string(len(out)) + ") for url: " + string(urlIn))
+		return
 	}
-	copy(htmlOut, o)
-	args[2].Invoke(len(o))
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, uint32(len(out))); err != nil {
+		errorOut(err.Error())
+		return
+	}
+	copy(htmlOut[:4], buf.Bytes())
+	copy(htmlOut[4:], out)
+	args[0].Invoke()
 }
 
-// Takes a slice. Returns a JS function that takes a JS function cb1, calls cb1
-// with a new TypedArray for the slice and a release function. The release
-// function takes a JS function cb2, releases the TypedArray and itself, and
-// calls cb2. Oh, the joys of continuation-passing style.
+// Takes a max len and a slice.
 //
-// The caller is responsible for releasing this function.
-func typedArrayGetter(slice interface{}) js.Callback {
-	return js.NewCallback(func(args []js.Value) {
+// Returns an object with two attributes:
+//   maxLen: the max len
+//   getter: JS function that takes a JS function cb1, calls cb1 with a new
+//     TypedArray for the slice and a release function. The release function
+//     takes a JS function cb2, releases the TypedArray and itself, and calls
+//     cb2. Oh, the joys of continuation-passing style.
+//
+// The getter is never released. It is presumed that this object will live for
+// the entire duration of the WASM process.
+func typedArray(maxLen uint32, slice interface{}) js.Value {
+	getter := js.NewCallback(func(args []js.Value) {
 		ta := js.TypedArrayOf(slice)
 		var release js.Callback
 		release = js.NewCallback(func(args []js.Value) {
@@ -72,6 +115,10 @@ func typedArrayGetter(slice interface{}) js.Callback {
 			args[0].Invoke()
 		})
 		args[0].Invoke(ta, release)
+	})
+	return js.ValueOf(map[string]interface{}{
+		"maxLen": maxLen,
+		"getter": getter,
 	})
 }
 
@@ -83,15 +130,15 @@ func main() {
 	doneCB := js.NewCallback(func(args []js.Value) { done <- struct{}{} })
 	defer doneCB.Release()
 
-	urlInCB := typedArrayGetter(urlIn)
-	defer urlInCB.Release()
+	// Invoke the JS callback, hardcoded as {global,window}.begin, once the
+	// Go is ready to receive transform requests.
+	js.Global().Get("begin").Invoke(
+		transformCB,
+		doneCB,
+		typedArray(urlInMaxLen, urlIn),
+		typedArray(htmlInMaxLen, htmlIn),
+		typedArray(htmlOutMaxLen, htmlOut))
 
-	htmlInCB := typedArrayGetter(htmlIn)
-	defer htmlInCB.Release()
-
-	htmlOutCB := typedArrayGetter(htmlOut)
-	defer htmlOutCB.Release()
-
-	js.Global().Get("begin").Invoke(transformCB, doneCB, urlInCB, htmlInCB, htmlOutCB, maxLen)
+	// Keep the Go process running until the JS calls the done callback.
 	<-done
 }


### PR DESCRIPTION
Stop leaking the length parameters, by including them as uint32 prefixes
in the typed arrays.

Eliminate the 15% cost of flyweight typed arrays by only recreating them
when they become detached.

Create a GoBytes class that wraps up all this messy logic into a simple
API.