### PR TITLE
Document leaky funcs in WASM wrapper.

### DIFF
--- a/cmd/transform_wasm/testfile
+++ b/cmd/transform_wasm/testfile
@@ -1,0 +1,13 @@
+>>>>>>>>>> Test Case <<<<<<<<<<
+http://example.com/amp
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="self.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>hello wasm</body>
+</html>


### PR DESCRIPTION
These are not worth worrying about as they will go away in Go 1.12.

Add optional dependency on heapdump library to generate heap snapshots,
which can be viewed with Chrome DevTools -> Memory -> Profiles -> right
click -> Load.

Add example test file.