### PR TITLE
 Fix faulty PathRE and create MaxLength.

### DIFF
--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -85,15 +85,7 @@ OCSPCache = '/tmp/amppkg-ocsp'
     Domain = "amppackageexample.com"
 
     # A full-match regexp on the path (not including the ?query). Defaults to
-    # ".{,2000}" -- that is, any path <= 2000 chars long.
-    #
-    # The length limit is to mitigate the risk of a content-sniffing attack
-    # (per https://github.com/WICG/webpackage/pull/348) against downstream
-    # servers that serve 200 responses regardless of some of the path
-    # components (e.g. looking up by id and not validating the slug in the
-    # requested URL). If your server only serves 200 responses on a limited set
-    # of valid URLs, and some of those URLs are >2000 chars, then it's safe to
-    # modify this default.
+    # ".*".
     #
     # The below example allows paths starting with /world/.
     # PathRE = "/world/.*"
@@ -122,6 +114,16 @@ OCSPCache = '/tmp/amppkg-ocsp'
     # are stripped from the response before packaging. If instead you wish for
     # this to cause packaging to fail, set ErrorOnStatefulHeaders = true.
     # ErrorOnStatefulHeaders = true
+
+    # The maximum length of the URL. Defaults to 2000 as this is a de facto
+    # limit anyway in many browsers. The limit is to mitigate the risk of a
+    # content-sniffing attack (per https://github.com/WICG/webpackage/pull/348)
+    # against downstream servers that serve 200 responses regardless of some of
+    # the path components (e.g. looking up by id and not validating the slug in
+    # the requested URL). If your server only serves 200 responses on a limited
+    # set of valid URLs, and some of those URLs are >2000 chars, then it's safe
+    # to modify this default.
+    # MaxLength = 2000
 
   # By default, the packager only looks at the sign param, and fetches the
   # content from the same location. If you'd like more flexibility (for

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -145,8 +145,8 @@ func (this *SignerSuite) SetupTest() {
 
 func (this *SignerSuite) TestSimple() {
 	urlSets := []util.URLSet{{
-		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, boolPtr(true)},
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
 	}}
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath)+
@@ -185,8 +185,8 @@ func (this *SignerSuite) TestSimple() {
 
 func (this *SignerSuite) TestParamsInPostBody() {
 	urlSets := []util.URLSet{{
-		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, boolPtr(true)},
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
 	}}
 	resp := this.getB(this.T(), this.new(urlSets), "/priv/doc",
 		"fetch="+url.QueryEscape(this.httpURL()+fakePath)+
@@ -201,8 +201,8 @@ func (this *SignerSuite) TestParamsInPostBody() {
 
 func (this *SignerSuite) TestEscapeQueryParamsInFetchAndSign() {
 	urlSets := []util.URLSet{{
-		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, nil},
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, boolPtr(true)},
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, nil},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, boolPtr(true)},
 	}}
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath+"?<hi>")+
@@ -217,7 +217,7 @@ func (this *SignerSuite) TestEscapeQueryParamsInFetchAndSign() {
 
 func (this *SignerSuite) TestNoFetchParam() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
 
@@ -229,7 +229,7 @@ func (this *SignerSuite) TestNoFetchParam() {
 
 func (this *SignerSuite) TestSignAsPathParam() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	resp := this.getP(this.T(), this.new(urlSets), `/priv/doc/`, httprouter.Params{httprouter.Param{"signURL", "/" + this.httpsURL() + fakePath}})
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -242,7 +242,7 @@ func (this *SignerSuite) TestSignAsPathParam() {
 
 func (this *SignerSuite) TestPreservesContentType() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html;charset=utf-8;v=5")
 		resp.Write(fakeBody)
@@ -257,7 +257,7 @@ func (this *SignerSuite) TestPreservesContentType() {
 
 func (this *SignerSuite) TestRemovesLinkHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Link", "rel=preload;<http://1.2.3.4/>")
@@ -273,7 +273,7 @@ func (this *SignerSuite) TestRemovesLinkHeaders() {
 
 func (this *SignerSuite) TestRemovesStatefulHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Set-Cookie", "yum yum yum")
@@ -289,7 +289,7 @@ func (this *SignerSuite) TestRemovesStatefulHeaders() {
 
 func (this *SignerSuite) TestAddsLinkHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Write([]byte("<html amp><head><link rel=stylesheet href=foo><script src=bar>"))
@@ -304,7 +304,7 @@ func (this *SignerSuite) TestAddsLinkHeaders() {
 
 func (this *SignerSuite) TestEscapesLinkHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		// This shouldn't happen for valid AMP, and AMP Caches should
@@ -324,7 +324,7 @@ func (this *SignerSuite) TestEscapesLinkHeaders() {
 
 func (this *SignerSuite) TestRemovesHopByHopHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Connection", "PROXY-AUTHENTICATE, Server")
@@ -347,7 +347,7 @@ func (this *SignerSuite) TestRemovesHopByHopHeaders() {
 
 func (this *SignerSuite) TestErrorNoCache() {
 	urlSets := []util.URLSet{{
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, boolPtr(true)},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
 	}}
 	// Missing sign param generates an error.
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath))
@@ -357,7 +357,7 @@ func (this *SignerSuite) TestErrorNoCache() {
 
 func (this *SignerSuite) TestProxyUnsignedIfRedirect() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -374,7 +374,7 @@ func (this *SignerSuite) TestProxyUnsignedIfRedirect() {
 
 func (this *SignerSuite) TestProxyUnsignedIfNotModified() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -393,7 +393,7 @@ func (this *SignerSuite) TestProxyUnsignedIfNotModified() {
 
 func (this *SignerSuite) TestProxyUnsignedIfShouldntPackage() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	this.shouldPackage = false
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
@@ -405,7 +405,7 @@ func (this *SignerSuite) TestProxyUnsignedIfShouldntPackage() {
 
 func (this *SignerSuite) TestProxyUnsignedIfMissingAMPCacheTransformHeader() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"Accept": {"application/signed-exchange;v=b2"}})
@@ -417,7 +417,7 @@ func (this *SignerSuite) TestProxyUnsignedIfMissingAMPCacheTransformHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedIfMissingAcceptHeader() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"AMP-Cache-Transform": {"google"}})
@@ -429,7 +429,7 @@ func (this *SignerSuite) TestProxyUnsignedIfMissingAcceptHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedErrOnStatefulHeader() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -446,7 +446,7 @@ func (this *SignerSuite) TestProxyUnsignedErrOnStatefulHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedNonCachable() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -463,7 +463,7 @@ func (this *SignerSuite) TestProxyUnsignedNonCachable() {
 
 func (this *SignerSuite) TestProxyUnsignedIfNotAMP() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	nonAMPBody := []byte("<html><body>They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)")
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -479,7 +479,7 @@ func (this *SignerSuite) TestProxyUnsignedIfNotAMP() {
 
 func (this *SignerSuite) TestProxyUnsignedIfWrongAMP() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil}}}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 	wrongAMPBody := []byte("<html amp4email><body>They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)")
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -495,7 +495,7 @@ func (this *SignerSuite) TestProxyUnsignedIfWrongAMP() {
 
 func (this *SignerSuite) TestProxyTransformError() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, nil},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 
 	// Generate a request for non-existent transformer that will fail

--- a/packager/signer/validation.go
+++ b/packager/signer/validation.go
@@ -79,6 +79,9 @@ func urlMatches(url *url.URL, pattern util.URLPattern) error {
 	if !regexpFullMatch(*pattern.QueryRE, url.RawQuery) {
 		return errors.New("QueryRE doesn't match")
 	}
+	if len(url.String()) > pattern.MaxLength {
+		return errors.New("URL too long")
+	}
 	return nil
 }
 

--- a/packager/signer/validation_test.go
+++ b/packager/signer/validation_test.go
@@ -35,53 +35,56 @@ func TestParseURL(t *testing.T) {
 func TestFetchURLMatches(t *testing.T) {
 	assert.NoError(t, fetchURLMatches(nil, nil))
 	assert.NoError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}))
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}))
 	assert.NoError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, Domain: "example.com", PathRE: stringPtr("/"), QueryRE: stringPtr("")}))
+		&util.URLPattern{Scheme: []string{"http"}, Domain: "example.com", PathRE: stringPtr("/"), QueryRE: stringPtr(""), MaxLength: 2000}))
 	assert.NoError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, DomainRE: "example.*", PathRE: stringPtr("/"), QueryRE: stringPtr("")}))
+		&util.URLPattern{Scheme: []string{"http"}, DomainRE: "example.*", PathRE: stringPtr("/"), QueryRE: stringPtr(""), MaxLength: 2000}))
 
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"), nil),
 		"If URLSet.Fetch is unspecified, then so should ?fetch= be.")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"https"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"https"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"Scheme doesn't match")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"http"}, Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"Domain doesn't match")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com:1234/"),
-		&util.URLPattern{Scheme: []string{"http"}, Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"http"}, Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"Domain doesn't match")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, DomainRE: "xample", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"http"}, DomainRE: "xample", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"DomainRE doesn't match")
 
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http:example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"URL is opaque")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://user@example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"URL contains user")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"PathRE doesn't match")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), PathExcludeRE: []string{"/"}, QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), PathExcludeRE: []string{"/"}, QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"PathExcludeRE matches: /")
 	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/?sessid=foo"),
-		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr("")}),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(""), MaxLength: 2000}),
 		"QueryRE doesn't match")
+	assert.EqualError(t, fetchURLMatches(urlOrDie("http://example.com/"),
+		&util.URLPattern{Scheme: []string{"http"}, PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 10}),
+		"URL too long")
 }
 
 func TestSignURLMatches(t *testing.T) {
 	assert.NoError(t, signURLMatches(urlOrDie("https://example.com/"),
-		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}))
+		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}))
 
 	assert.EqualError(t, signURLMatches(urlOrDie("http://example.com/"),
-		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"Scheme doesn't match")
 	assert.EqualError(t, signURLMatches(urlOrDie("https://wrongexample.com/"),
-		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}),
+		&util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}),
 		"Domain doesn't match")
 }
 
@@ -89,11 +92,11 @@ func TestURLsMatch(t *testing.T) {
 	config := util.URLSet{
 		Fetch: &util.URLPattern{
 			Scheme: []string{"http"}, Domain: "fetch.com",
-			PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"),
+			PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000,
 			SamePath: boolPtr(true)},
 		Sign: &util.URLPattern{
 			Domain: "sign.com",
-			PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")},
+			PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000},
 	}
 
 	assert.NoError(t, urlsMatch(urlOrDie("http://fetch.com/"), urlOrDie("https://sign.com/"), config))
@@ -118,10 +121,10 @@ func TestParseURLs(t *testing.T) {
 	}
 
 	fetch, sign, errorOnStatefulHeaders, err := parseURLs("", "https://example.com/", []util.URLSet{
-		{Sign: &util.URLPattern{Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
-		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*")}},
-		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), ErrorOnStatefulHeaders: true}},
-		{Sign: &util.URLPattern{Domain: "badexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
+		{Sign: &util.URLPattern{Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}},
+		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*"), MaxLength: 2000}},
+		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000, ErrorOnStatefulHeaders: true}},
+		{Sign: &util.URLPattern{Domain: "badexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}},
 	})
 	if assert.Nil(t, err) {
 		assert.Equal(t, "https://example.com/", fetch.String())
@@ -130,9 +133,9 @@ func TestParseURLs(t *testing.T) {
 	}
 
 	_, _, _, err = parseURLs("", "https://example.com/", []util.URLSet{
-		{Sign: &util.URLPattern{Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
-		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*")}},
-		{Sign: &util.URLPattern{Domain: "badexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*")}},
+		{Sign: &util.URLPattern{Domain: "wrongexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}},
+		{Sign: &util.URLPattern{Domain: "example.com", PathRE: stringPtr("/amp/.*"), QueryRE: stringPtr(".*"), MaxLength: 2000}},
+		{Sign: &util.URLPattern{Domain: "badexample.com", PathRE: stringPtr(".*"), QueryRE: stringPtr(".*"), MaxLength: 2000}},
 	})
 	if assert.NotNil(t, err) {
 		assert.EqualError(t, err, "fetch/sign URLs do not match config")

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -49,6 +49,10 @@ type URLPattern struct {
 	SamePath               *bool
 }
 
+// TODO(twifkak): Extract default values into a function separate from the one
+// that does the parsing and validation. This would make signer_test and
+// validation_test less brittle.
+
 var emptyRegexp = ""
 var defaultPathRegexp = ".*"
 

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -45,11 +45,12 @@ type URLPattern struct {
 	PathExcludeRE          []string
 	QueryRE                *string
 	ErrorOnStatefulHeaders bool
+	MaxLength              int
 	SamePath               *bool
 }
 
 var emptyRegexp = ""
-var defaultPathRegexp = ".{,2000}"
+var defaultPathRegexp = ".*"
 
 // Also sets defaults.
 func validateURLPattern(pattern *URLPattern) error {
@@ -67,6 +68,9 @@ func validateURLPattern(pattern *URLPattern) error {
 		pattern.QueryRE = &emptyRegexp
 	} else if _, err := regexp.Compile(*pattern.QueryRE); err != nil {
 		return errors.New("QueryRE must be a valid regexp")
+	}
+	if pattern.MaxLength == 0 {
+		pattern.MaxLength = 2000
 	}
 	return nil
 }

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -43,7 +43,7 @@ func TestMinimalValidConfig(t *testing.T) {
 		URLSet: []URLSet{{
 			Sign: &URLPattern{
 				Domain:  "example.com",
-				PathRE:  stringPtr(".{,2000}"),
+				PathRE:  stringPtr(".*"),
 				QueryRE: stringPtr(""),
 			},
 		}},
@@ -186,7 +186,7 @@ func TestFetchDefaults(t *testing.T) {
 	assert.ElementsMatch(t, []string{"http", "https"}, fetch.Scheme)
 	assert.Equal(t, "", fetch.DomainRE)
 	assert.Equal(t, "example.com", fetch.Domain)
-	assert.Equal(t, stringPtr(".{,2000}"), fetch.PathRE)
+	assert.Equal(t, stringPtr(".*"), fetch.PathRE)
 	assert.Nil(t, fetch.PathExcludeRE)
 	assert.Equal(t, stringPtr(""), fetch.QueryRE)
 	assert.Equal(t, false, fetch.ErrorOnStatefulHeaders)

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -45,6 +45,7 @@ func TestMinimalValidConfig(t *testing.T) {
 				Domain:  "example.com",
 				PathRE:  stringPtr(".*"),
 				QueryRE: stringPtr(""),
+				MaxLength: 2000,
 			},
 		}},
 	}, *config)
@@ -156,6 +157,7 @@ func TestSignOverrides(t *testing.T) {
 		    PathExcludeRE = ["/amp/signin", "/amp/settings(/.*)?"]
 		    QueryRE = ""
 		    ErrorOnStatefulHeaders = true
+		    MaxLength = 8000
 	`))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(config.URLSet))
@@ -166,6 +168,7 @@ func TestSignOverrides(t *testing.T) {
 		PathExcludeRE:          []string{"/amp/signin", "/amp/settings(/.*)?"},
 		QueryRE:                stringPtr(""),
 		ErrorOnStatefulHeaders: true,
+		MaxLength:              8000,
 	}, *config.URLSet[0].Sign)
 }
 
@@ -190,6 +193,7 @@ func TestFetchDefaults(t *testing.T) {
 	assert.Nil(t, fetch.PathExcludeRE)
 	assert.Equal(t, stringPtr(""), fetch.QueryRE)
 	assert.Equal(t, false, fetch.ErrorOnStatefulHeaders)
+	assert.Equal(t, 2000, fetch.MaxLength)
 	assert.Equal(t, boolPtr(true), fetch.SamePath)
 }
 
@@ -207,6 +211,7 @@ func TestFetchOverrides(t *testing.T) {
 		    PathRE = "/amp/.*"
 		    PathExcludeRE = ["/amp/signin", "/amp/settings(/.*)?"]
 		    QueryRE = ""
+		    MaxLength = 8000
 		    SamePath = false
 	`))
 	require.NoError(t, err)
@@ -217,6 +222,7 @@ func TestFetchOverrides(t *testing.T) {
 		PathRE:        stringPtr("/amp/.*"),
 		PathExcludeRE: []string{"/amp/signin", "/amp/settings(/.*)?"},
 		QueryRE:       stringPtr(""),
+		MaxLength:     8000,
 		SamePath:      boolPtr(false),
 	}, *config.URLSet[0].Fetch)
 }


### PR DESCRIPTION
Move the 2000-char limit from the PathRE into a separate MaxLength
config field. The regex was not valid syntax per
https://github.com/google/re2/wiki/Syntax. This was broken in commit
2ea2f2d (#214).

Fixes #226.