### PR TITLE
Fix JS memory leak.

### DIFF
--- a/cmd/transform_wasm/README.md
+++ b/cmd/transform_wasm/README.md
@@ -19,8 +19,9 @@ To run the test:
 ```bash
 git clone https://github.com/ampproject/amppackager.git
 cd amppackager
-node --max-old-space-size=4000 cmd/transform_wasm/main.js \
-  ${GOROOT:-~/.go}/bin/js_wasm/transform_wasm cmd/transform_wasm/testfile
+node cmd/transform_wasm/main.js ${GOROOT:-~/.go}/bin/js_wasm/transform_wasm cmd/transform_wasm/testfile
 ```
+
+For a bigger testfile, pass `node` something like `--max-old-space-size=4000`.
 
 lib.js can be reused for other purposes. See main.js for an example use.

--- a/cmd/transform_wasm/main.js
+++ b/cmd/transform_wasm/main.js
@@ -96,7 +96,7 @@ async function readTestFiles() {
 const heapdump = (() => { try { return require('heapdump') } catch { } })(); // npm install heapdump
 function dumpHeap(name, full) {
   console.log('%s: %s', name, util.inspect(process.memoryUsage(), {colors: true, breakLength: Infinity}))
-  if (full && heapdump) heapdump.writeSnapshot('wasm.' + name + '.heapsnapshot');
+  if (full && heapdump) heapdump.writeSnapshot('wasm.js.' + name + '.heapsnapshot');
 }
 
 global.begin = async function(done) {


### PR DESCRIPTION
This was introduced in commit 2c935ddf (#228), which was the first to
return the transformed html via the Promise. Fixed by having the lambda
only close over one global variable rather than one local variable per
function call.

Also, added heap profiling instrumentation to the Go code to confirm
there isn't a memory leak inside the wasm memory.

Finally, cleaned up the internal API a bit.