### PR TITLE
Update cmds from b2 to b3.

### DIFF
--- a/cmd/amppkg_dl_sxg/main.go
+++ b/cmd/amppkg_dl_sxg/main.go
@@ -23,7 +23,7 @@ func getSXG(url string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	req.Header.Set("Accept", "application/signed-exchange;v=b2")
+	req.Header.Set("Accept", "application/signed-exchange;v=b3")
 	req.Header.Set("AMP-Cache-Transform", "any")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/cmd/amppkg_test_cache/main.go
+++ b/cmd/amppkg_test_cache/main.go
@@ -77,7 +77,7 @@ func main() {
 		http.ServeFile(resp, req, *flagCert)
 	})
 	http.HandleFunc("/test.sxg", func(resp http.ResponseWriter, req *http.Request) {
-		resp.Header().Set("Content-Type", "application/signed-exchange;v=b2")
+		resp.Header().Set("Content-Type", "application/signed-exchange;v=b3")
 		http.ServeContent(resp, req, "test.sxg", time.Time{}, sxgReader)
 	})
 	log.Println("Serving on port", *flagPort)


### PR DESCRIPTION
This fix is to update the commands of `amppkg_dl_sxg` and `amppkg_test_cache` from b2 to b3.

From CONTRIBUTING.md,  
- My Google Individual CLA was already signed.
- `go test` and `go fmt` are fine as below.

```
$ go fmt cmd/amppkg_dl_sxg/main.go
$ go fmt cmd/amppkg_test_cache/main.go
```
```
$ go test ./...
?       github.com/ampproject/amppackager/cmd/amppkg    [no test files]
?       github.com/ampproject/amppackager/cmd/amppkg_dl_sxg     [no test files]
?       github.com/ampproject/amppackager/cmd/amppkg_test_cache [no test files]
?       github.com/ampproject/amppackager/cmd/transform [no test files]
ok      github.com/ampproject/amppackager/packager/accept       (cached)
ok      github.com/ampproject/amppackager/packager/amp_cache_transform  (cached)
ok      github.com/ampproject/amppackager/packager/certcache    (cached)
ok      github.com/ampproject/amppackager/packager/rtv  (cached)
ok      github.com/ampproject/amppackager/packager/signer       (cached)
?       github.com/ampproject/amppackager/packager/testing      [no test files]
ok      github.com/ampproject/amppackager/packager/util (cached)
ok      github.com/ampproject/amppackager/packager/validitymap  (cached)
ok      github.com/ampproject/amppackager/transformer   (cached)
ok      github.com/ampproject/amppackager/transformer/internal/amphtml  (cached)
ok      github.com/ampproject/amppackager/transformer/internal/css      (cached)
ok      github.com/ampproject/amppackager/transformer/internal/htmlnode (cached)
?       github.com/ampproject/amppackager/transformer/internal/testing  [no test files]
ok      github.com/ampproject/amppackager/transformer/layout    (cached)
ok      github.com/ampproject/amppackager/transformer/printer   (cached)
?       github.com/ampproject/amppackager/transformer/request   [no test files]
ok      github.com/ampproject/amppackager/transformer/transformers      (cached)
```