### PR TITLE
Remove PackagerBase from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ own and can obtain certificates for.
   3. Create a file `amppkg.toml`. A minimal config looks like this:
      ```
      LocalOnly = true
-     PackagerBase = 'https://localhost:8080/'
      CertFile = 'path/to/fullchain.pem'
      KeyFile = 'path/to/privkey.pem'
      OCSPCache = '/tmp/amppkg-ocsp'


### PR DESCRIPTION
`PackagerBase` doesn't exist any more after https://github.com/ampproject/amppackager/pull/113 merged. Not to be confusing, I just removed it from README documentation.