### PR TITLE
Don't sign versioned Variants headers.

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -398,7 +398,9 @@ func (this *Signer) ServeHTTP(resp http.ResponseWriter, req *http.Request, param
 
 		fetchResp.Header.Del("Link") // Ensure there are no privacy-violating Link:rel=preload headers.
 
-		if fetchResp.Header.Get("Variants") != "" || fetchResp.Header.Get("Variant-Key") != "" {
+		if fetchResp.Header.Get("Variants") != "" || fetchResp.Header.Get("Variant-Key") != "" ||
+			// Include versioned headers per https://github.com/WICG/webpackage/pull/406.
+			fetchResp.Header.Get("Variants-04") != "" || fetchResp.Header.Get("Variant-Key-04") != "" {
 			// Variants headers (https://tools.ietf.org/html/draft-ietf-httpbis-variants-04) are disallowed by AMP Cache.
 			// We could delete the headers, but it's safest to assume they reflect the downstream server's intent.
 			log.Println("Not packaging because response contains a Variants header.")

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -540,6 +540,22 @@ func (this *SignerSuite) TestProxyUnsignedOnVariants() {
 	this.Assert().Equal("text/html", resp.Header.Get("Content-Type"))
 }
 
+func (this *SignerSuite) TestProxyUnsignedOnVariants04() {
+	urlSets := []util.URLSet{{
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil},
+	}}
+	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
+		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
+		resp.Header().Set("Variants-04", "foo")
+		resp.Header().Set("Content-Type", "text/html")
+		resp.WriteHeader(200)
+	}
+
+	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
+	this.Assert().Equal(200, resp.StatusCode)
+	this.Assert().Equal("foo", resp.Header.Get("Variants-04"))
+	this.Assert().Equal("text/html", resp.Header.Get("Content-Type"))
+}
 
 func (this *SignerSuite) TestProxyUnsignedIfNotAMP() {
 	urlSets := []util.URLSet{{


### PR DESCRIPTION
These are the ones that Chromium actually uses at the moment, per
https://crrev.com/86e0430c.