### PR TITLE
Support new -invalidcert flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ packager URL directly, first add a Chrome extension to send an
 
 It is possible to test an otherwise fully production configuration without
 obtaining a certificate with the `CanSignHttpExchanges` extension. `amppkg`
-still needs to perform OCSP verification, so the Root CA must be valid (i.e. no
+still needs to perform OCSP verification, so the Issuer CA must be valid (i.e. no
 self-signed certificates). e.g. You can use a certificate from [Let's Encrypt](https://letsencrypt.org/).
 
 Running `amppkg` with the `-invalidcert` flag will skip the check for

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ packager URL directly, first add a Chrome extension to send an
 `AMP-Cache-Transform: any` request header. Otherwise, follow the above
 "Demonstrate privacy-preserving prefetch" instructions.
 
+#### Testing productionization without a valid certificate
+
+It is possible to test an otherwise fully production configuration without
+obtaining a certificate with the `CanSignHttpExchanges` extension. `amppkg`
+still needs to perform OCSP verification, so the Root CA must be valid (i.e. no
+self-signed certificates). e.g. You can use a certificate from [Let's Encrypt](https://letsencrypt.org/).
+
+Running `amppkg` with the `-invalidcert` flag will skip the check for
+`CanSignHttpExchanges`. This flag is not necessary when using the
+`-development` flag.
+
+Chrome can be configured to allow these invalid certificates with the
+*Allow Signed HTTP Exchange certificates without extension* experiment:
+chrome://flags/#allow-sxg-certs-without-extension
+
 #### Redundancy
 
 If you need to load balance across multiple instances of `amppkg`, you'll want

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	packager, err := signer.New(certs[0], key, config.URLSet, rtvCache, certCache.IsHealthy,
-		overrideBaseURL, /*requireHeaders=*/!(*flagDevelopment || *flagInvalidCert))
+		overrideBaseURL, /*requireHeaders=*/!*flagDevelopment)
 	if err != nil {
 		die(errors.Wrap(err, "building packager"))
 	}

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -91,7 +91,7 @@ func main() {
 	if certs == nil || len(certs) == 0 {
 		die(fmt.Sprintf("no cert found in %s", config.CertFile))
 	}
-	if (!*flagDevelopment && !*flagInvalidCert) && !util.CanSignHttpExchanges(certs[0]) {
+	if !(*flagDevelopment || *flagInvalidCert) && !util.CanSignHttpExchanges(certs[0]) {
 		die("cert is missing CanSignHttpExchanges extension")
 	}
 	// TODO(twifkak): Verify that certs[0] covers all the signing domains in the config.
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	packager, err := signer.New(certs[0], key, config.URLSet, rtvCache, certCache.IsHealthy,
-		overrideBaseURL, /*requireHeaders=*/!*flagDevelopment && !*flagInvalidCert)
+		overrideBaseURL, /*requireHeaders=*/!(*flagDevelopment || *flagInvalidCert))
 	if err != nil {
 		die(errors.Wrap(err, "building packager"))
 	}

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -91,7 +91,7 @@ func main() {
 	if certs == nil || len(certs) == 0 {
 		die(fmt.Sprintf("no cert found in %s", config.CertFile))
 	}
-	if !(*flagDevelopment || *flagInvalidCert) && !util.CanSignHttpExchanges(certs[0]) {
+	if !(*flagDevelopment || *flagInvalidCert || util.CanSignHttpExchanges(certs[0])) {
 		die("cert is missing CanSignHttpExchanges extension")
 	}
 	// TODO(twifkak): Verify that certs[0] covers all the signing domains in the config.

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -40,6 +40,7 @@ import (
 
 var flagConfig = flag.String("config", "amppkg.toml", "Path to the config toml file.")
 var flagDevelopment = flag.Bool("development", false, "True if this is a development server.")
+var flagInvalidCert = flag.Bool("invalidcert", false, "True if invalid certificate intentionally used in production.")
 
 // Prints errors returned by pkg/errors with stack traces.
 func die(err interface{}) { log.Fatalf("%+v", err) }
@@ -90,7 +91,7 @@ func main() {
 	if certs == nil || len(certs) == 0 {
 		die(fmt.Sprintf("no cert found in %s", config.CertFile))
 	}
-	if !*flagDevelopment && !util.CanSignHttpExchanges(certs[0]) {
+	if (!*flagDevelopment && !*flagInvalidCert) && !util.CanSignHttpExchanges(certs[0]) {
 		die("cert is missing CanSignHttpExchanges extension")
 	}
 	// TODO(twifkak): Verify that certs[0] covers all the signing domains in the config.
@@ -126,7 +127,7 @@ func main() {
 	}
 
 	packager, err := signer.New(certs[0], key, config.URLSet, rtvCache, certCache.IsHealthy,
-		overrideBaseURL, /*requireHeaders=*/!*flagDevelopment)
+		overrideBaseURL, /*requireHeaders=*/!*flagDevelopment && !*flagInvalidCert)
 	if err != nil {
 		die(errors.Wrap(err, "building packager"))
 	}
@@ -170,6 +171,9 @@ func main() {
 	if *flagDevelopment {
 		log.Println("WARNING: Running in development, using SXG key for TLS. This won't work in production.")
 		log.Fatal(server.ListenAndServeTLS(config.CertFile, config.KeyFile))
+	} else if *flagInvalidCert {
+		log.Println("WARNING: Running in production without valid signing certificate. Signed exchanges will not be valid.")
+		log.Fatal(server.ListenAndServe())
 	} else {
 		log.Fatal(server.ListenAndServe())
 	}


### PR DESCRIPTION
Run amppackager in production mode with known invalid SSL certificates.
Useful to emulate an otherwise fully production environment without
having to pay the sole provider of SSL certificates with
CanSignHttpExchanges extension.