### PR TITLE
certcache: Log chained Read error

### DIFF
--- a/packager/certcache/storage.go
+++ b/packager/certcache/storage.go
@@ -135,6 +135,7 @@ func (this *Chained) Read(ctx context.Context, isExpired func([]byte) bool, upda
 	return this.first.Read(ctx, isExpired, func([]byte) []byte {
 		contents, err := this.second.Read(ctx, isExpired, update)
 		if err != nil {
+			log.Printf("%+v", err)
 			return nil
 		}
 		return contents


### PR DESCRIPTION
When an error occurs in the second ocsp Read method, it is not passed
back to readOCSP, making it difficult to determine what went wrong.
All errors look like empty contents, "Missing OCSP response." Log the
error before setting contents to nil.