### PR TITLE
Support HEAD requests

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -137,9 +137,13 @@ func main() {
 	mux.RedirectTrailingSlash = false
 	mux.RedirectFixedPath = false
 	mux.GET(util.ValidityMapPath, validityMap.ServeHTTP)
+	mux.HEAD(util.ValidityMapPath, validityMap.ServeHTTP)
 	mux.GET("/priv/doc", packager.ServeHTTP)
+	mux.HEAD("/priv/doc", packager.ServeHTTP)
 	mux.GET("/priv/doc/*signURL", packager.ServeHTTP)
+	mux.HEAD("/priv/doc/*signURL", packager.ServeHTTP)
 	mux.GET(path.Join(util.CertURLPrefix, ":certName"), certCache.ServeHTTP)
+	mux.HEAD(path.Join(util.CertURLPrefix, ":certName"), certCache.ServeHTTP)
 	addr := ""
 	if config.LocalOnly {
 		addr = "localhost"


### PR DESCRIPTION
Perform identical operations as used in GET requests for doc, cert, and
validity. Rely on the http server to blank the body before responding.

Resolves #261