### PR TITLE
signer: Avoid mutating response until signing

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -476,7 +476,8 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 		fetchResp.Header.Del(header)
 	}
 
-	// Set or remove Link header.
+	// Set Link header if formatting returned a valid value, otherwise, delete
+	// it to ensure there are no privacy-violating Link:rel=preload headers.
 	if linkHeader != "" {
 		fetchResp.Header.Set("Link", linkHeader)
 	} else {

--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -348,17 +348,16 @@ func (this *Signer) ServeHTTP(resp http.ResponseWriter, req *http.Request, param
 		proxy(resp, fetchResp, nil)
 		return
 	}
+	var act string
 	var transformVersion int64
 	if this.requireHeaders {
 		header_value := GetJoined(req.Header, "AMP-Cache-Transform")
-		var act string
 		act, transformVersion = amp_cache_transform.ShouldSendSXG(header_value)
 		if act == "" {
 			log.Println("Not packaging because AMP-Cache-Transform request header is invalid:", header_value)
 			proxy(resp, fetchResp, nil)
 			return
 		}
-		resp.Header().Set("AMP-Cache-Transform", act)
 	} else {
 		var err error
 		transformVersion, err = transformer.SelectVersion(nil)
@@ -399,7 +398,7 @@ func (this *Signer) ServeHTTP(resp http.ResponseWriter, req *http.Request, param
 			return
 		}
 
-		this.serveSignedExchange(resp, fetchResp, signURL, transformVersion)
+		this.serveSignedExchange(resp, fetchResp, signURL, act, transformVersion)
 
 	case 304:
 		// If fetchURL returns a 304, then also return a 304 with appropriate headers.
@@ -442,7 +441,7 @@ func formatLinkHeader(preloads []*rpb.Metadata_Preload) (string, error) {
 }
 
 // serveSignedExchange does the actual work of transforming, packaging and signed and writing to the response.
-func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *http.Response, signURL *url.URL, transformVersion int64) {
+func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *http.Response, signURL *url.URL, act string, transformVersion int64) {
 	// After this, fetchResp.Body is consumed, and attempts to read or proxy it will result in an empty body.
 	fetchBody, err := ioutil.ReadAll(io.LimitReader(fetchResp.Body, maxBodyLength))
 	if err != nil {
@@ -533,6 +532,13 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 	var body bytes.Buffer
 	if err := exchange.Write(&body); err != nil {
 		util.NewHTTPError(http.StatusInternalServerError, "Error serializing exchange: ", err).LogAndRespond(resp)
+	}
+
+	// If requireHeaders was true when constructing signer, the
+	// AMP-Cache-Transform outer response header is required (and has already
+	// been validated)
+	if (act != "") {
+		resp.Header().Set("AMP-Cache-Transform", act)
 	}
 
 	// TODO(twifkak): Add Cache-Control: public with expiry to match when we think the AMP Cache


### PR DESCRIPTION
After successfully (200) fetching an AMP document, complete all
validation steps that could result in proxying the original response
before mutating any headers.

Resolves #279 