### PR TITLE
Remove warning about code, and add one about spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # AMP Packager
 
-> **WARNING**: This code is still evolving, and is a developer preview. The
-> specification is still changing, and this is an implementation of a snapshot
-> of it. Feel free to use it, but treat with care how you configure and deploy it.
-
 AMP Packager is a tool to [improve AMP
 URLs](https://www.ampproject.org/latest/blog/developer-preview-of-better-amp-urls-in-google-search).
 By running it in a proper configuration, web publishers may (eventually) have
@@ -149,6 +145,21 @@ chrome://flags/#enable-signed-http-exchange is enabled. To test by visiting the
 packager URL directly, first add a Chrome extension to send an
 `AMP-Cache-Transform: any` request header. Otherwise, follow the above
 "Demonstrate privacy-preserving prefetch" instructions.
+
+##### Security Considerations
+
+Signed exchanges come with some [security
+considerations](https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#security-considerations)
+that publishers should consider. A starting list of recommendations based on
+that:
+
+ * Use different keys for the signed exchange cert and the TLS cert.
+ * Only sign public content that's OK to be shared with crawlers.
+ * Don't sign personalized content. (It's OK to sign content that includes
+   static JS that adds personalization at runtime.)
+ * Be careful when signing inline JS; if it includes a vulnerability, it may be
+   possible for attackers to exploit it without intercepting the network path,
+   for up to 7 days.
 
 #### Testing productionization without a valid certificate
 


### PR DESCRIPTION
Remove the warning about the code being in developer preview; we
consider it stable enough to deploy in production now. Both code and
specification are still evolving, but this is handled by the requirement
to keep the packager updated per the `AMP-Cache-Transform` version.

Add a warning about SXG security considerations. This is an attempt to
distill advice from the risks outlined in the spec.

cc @jyasskin