### PR TITLE
Check not to have TE in config.ForwardedRequestHeaders

### DIFF
--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -115,6 +115,18 @@ func TestForwardedRequestHeadersHaveDisallowedHeader(t *testing.T) {
 	`))), "ForwardedRequestHeaders must not include request header of via")
 }
 
+func TestForwardedRequestHeadersHaveTE(t *testing.T) {
+	assert.Contains(t, errorFrom(ReadConfig([]byte(`
+		CertFile = "cert.pem"
+		KeyFile = "key.pem"
+		OCSPCache = "/tmp/ocsp"
+		ForwardedRequestHeaders = ["X-Foo", "X-Bar", "TE"]
+		[[URLSet]]
+		  [URLSet.Sign]
+		    Domain = "example.com"
+	`))), "ForwardedRequestHeaders must not include request header of TE")
+}
+
 func TestOCSPDirDoesntExist(t *testing.T) {
 	assert.Contains(t, errorFrom(ReadConfig([]byte(`
 		CertFile = "cert.pem"

--- a/packager/util/http.go
+++ b/packager/util/http.go
@@ -45,7 +45,10 @@ var legacyHeaders = map[string]bool{
 // Via is implicitly forwarded and disallowed to be included in
 // config.ForwardedRequestHeaders
 // TE is a hop-by-hop request header and must not be forwarded.
+// Proxy-Authorization can be forwarded per rfc7235#section-4.4 but
+// remove it to mitigate the risk of over-signing.
 var notForwardedRequestHeader = map[string]bool{
+	"Proxy-Authorization": true,
 	"Te": true,
 	"Via": true,
 }

--- a/packager/util/http.go
+++ b/packager/util/http.go
@@ -44,7 +44,9 @@ var legacyHeaders = map[string]bool{
 
 // Via is implicitly forwarded and disallowed to be included in
 // config.ForwardedRequestHeaders
+// TE is a hop-by-hop request header and must not be forwarded.
 var notForwardedRequestHeader = map[string]bool{
+	"Te": true,
 	"Via": true,
 }
 


### PR DESCRIPTION
Per #311, I missed that `TE` must not be included in `config.ForwardedRequestHeaders`. 

For `Proxy-Authorization`,  it can be forwarded as
> A proxy MAY relay the credentials from the client request to the next proxy if that is the mechanism by which the proxies cooperatively authenticate a given request.

described in https://tools.ietf.org/html/rfc7235#section-4.4.