### PR TITLE
Remove etag on /amppkg/cert URL.

### DIFF
--- a/packager/certcache/certcache.go
+++ b/packager/certcache/certcache.go
@@ -169,7 +169,6 @@ func (this *CertCache) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 			expiry = 0
 		}
 		resp.Header().Set("Cache-Control", "public, max-age="+strconv.Itoa(expiry))
-		resp.Header().Set("ETag", "\""+this.certName+"\"")
 		resp.Header().Set("X-Content-Type-Options", "nosniff")
 		cbor, err := this.createCertChainCBOR(ocsp)
 		if err != nil {


### PR DESCRIPTION
It is incorrect, since it contains only the certName, but the cert
contents vary when the OCSP response is updated. This is conflicting
with caching intermediaries.

Addresses b/135545532.