### PR TITLE
Be explicit about the SXG cache lifetime.

### DIFF
--- a/packager/signer/validation_test.go
+++ b/packager/signer/validation_test.go
@@ -13,8 +13,6 @@ import (
 
 func urlFrom(url *url.URL, err *util.HTTPError) *url.URL { return url }
 
-func errorFrom(url *url.URL, err *util.HTTPError) *util.HTTPError { return err }
-
 func urlOrDie(spec string) *url.URL {
 	url, err := url.Parse(spec)
 	if err != nil {
@@ -24,6 +22,8 @@ func urlOrDie(spec string) *url.URL {
 }
 
 func TestParseURL(t *testing.T) {
+	errorFrom := func(url *url.URL, err *util.HTTPError) *util.HTTPError { return err }
+
 	assert.EqualError(t, errorFrom(parseURL("", "sign")), "sign URL is unspecified")
 	if err := errorFrom(parseURL("abc-@#79!%^/", "sign")); assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "Error parsing sign URL")


### PR DESCRIPTION
The previous behavior didn't specify a max age, which leads to
unspecified behavior.

Set to "max-age=0" for now, which allows caching on intermediaries, but
recommends they update every time.

A future change could relax that max age. However, be careful when doing
so, as the failure behavior of an expired SXG is a different UX than
that of an expired unsigned response.