### PR TITLE
Limit signature duration based on max_age_secs.

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -122,15 +122,15 @@ type Signer struct {
 	// TODO(twifkak): Support multiple certs. This will require generating
 	// a signature for each one. Note that Chrome only supports 1 signature
 	// at the moment.
-	certHandler	certcache.CertHandler
+	certHandler certcache.CertHandler
 	// TODO(twifkak): Do we want to allow multiple keys?
-	key             crypto.PrivateKey
-	client          *http.Client
-	urlSets         []util.URLSet
-	rtvCache        *rtv.RTVCache
-	shouldPackage   func() bool
-	overrideBaseURL *url.URL
-	requireHeaders  bool
+	key                     crypto.PrivateKey
+	client                  *http.Client
+	urlSets                 []util.URLSet
+	rtvCache                *rtv.RTVCache
+	shouldPackage           func() bool
+	overrideBaseURL         *url.URL
+	requireHeaders          bool
 	forwardedRequestHeaders []string
 }
 
@@ -479,7 +479,7 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 	}
 	// Expires - Date must be <= 604800 seconds, per
 	// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-3.5.
-	duration := 7*24*time.Hour
+	duration := 7 * 24 * time.Hour
 	println("max-age=", metadata.MaxAgeSecs)
 	if maxAge := time.Duration(metadata.MaxAgeSecs) * time.Second; maxAge < duration {
 		duration = maxAge
@@ -508,7 +508,7 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 	// If requireHeaders was true when constructing signer, the
 	// AMP-Cache-Transform outer response header is required (and has already
 	// been validated)
-	if (act != "") {
+	if act != "" {
 		resp.Header().Set("AMP-Cache-Transform", act)
 	}
 

--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -480,7 +480,6 @@ func (this *Signer) serveSignedExchange(resp http.ResponseWriter, fetchResp *htt
 	// Expires - Date must be <= 604800 seconds, per
 	// https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-00#section-3.5.
 	duration := 7 * 24 * time.Hour
-	println("max-age=", metadata.MaxAgeSecs)
 	if maxAge := time.Duration(metadata.MaxAgeSecs) * time.Second; maxAge < duration {
 		duration = maxAge
 	}

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -58,8 +58,8 @@ func headerNames(headers http.Header) []string {
 type fakeCertHandler struct {
 }
 
-func (this fakeCertHandler)  GetLatestCert() (*x509.Certificate) {
-	return pkgt.Certs[0] 
+func (this fakeCertHandler) GetLatestCert() *x509.Certificate {
+	return pkgt.Certs[0]
 }
 
 type SignerSuite struct {
@@ -613,7 +613,7 @@ func (this *SignerSuite) TestProxyUnsignedIfInvalidAMPCacheTransformHeader() {
 		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
-		"Accept": {"application/signed-exchange;v=" + accept.AcceptedSxgVersion},
+		"Accept":              {"application/signed-exchange;v=" + accept.AcceptedSxgVersion},
 		"AMP-Cache-Transform": {"donotmatch"},
 	})
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -783,10 +783,10 @@ func (this *SignerSuite) TestProxyHeadersUnaltered() {
 			Transformers:   []string{"bogus"}}
 	}
 
-	originalHeaders := map[string]string {
-		"Content-Type": "text/html",
-		"Set-Cookie": "chocolate chip",
-		"Cache-Control": "max-age=31536000",
+	originalHeaders := map[string]string{
+		"Content-Type":   "text/html",
+		"Set-Cookie":     "chocolate chip",
+		"Cache-Control":  "max-age=31536000",
 		"Content-Length": fmt.Sprintf("%d", len(fakeBody)),
 	}
 


### PR DESCRIPTION
This uses the new metadata field returned from the transformer library,
which is based on the presence of any inline amp-scripts.

@Gregable Note for review to ignore the first commit; it's merely the "diffbase" of #347.

cc @choumx 