### PR TITLE
Fix certcache to allow self-signed certs.

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"crypto/ecdsa"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -87,7 +88,12 @@ func main() {
 		die(errors.Wrap(err, "loading key file"))
 	}
 
-	certCache, err := certcache.PopulateCertCache(config, key, *flagDevelopment || *flagInvalidCert, *flagAutoRenewCert)
+	var responder certcache.OCSPResponder = nil
+	if *flagDevelopment {
+		// Key is guaranteed to be ECDSA by signedexchange.ParsePrivateKey. This may change in future versions of SXG.
+		responder = fakeOCSPResponder{key: key.(*ecdsa.PrivateKey)}.Respond
+	}
+	certCache, err := certcache.PopulateCertCache(config, key, responder, *flagDevelopment || *flagInvalidCert, *flagAutoRenewCert)
 	if err != nil {
 		die(errors.Wrap(err, "building cert cache"))
 	}

--- a/cmd/amppkg/ocsp.go
+++ b/cmd/amppkg/ocsp.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"time"
+
+	"golang.org/x/crypto/ocsp"
+)
+
+// A fake OCSP responder for the SXG certificate. Abstracted from certcache so as not to give it direct access to the private key.
+// Assumes that the given cert is self-signed, and therefore that the
+// configured KeyFile also corresponds to the cert's issuer.
+type fakeOCSPResponder struct {
+	key crypto.Signer
+}
+
+// Generates a current OCSP response for the given certificate.
+func (this fakeOCSPResponder) Respond(cert *x509.Certificate) ([]byte, error) {
+	thisUpdate := time.Now()
+
+	// Construct args to ocsp.CreateResponse.
+	template := ocsp.Response{
+		SerialNumber: cert.SerialNumber,
+		Status:       ocsp.Good,
+		ThisUpdate:   thisUpdate,
+		NextUpdate:   thisUpdate.Add(time.Hour * 24 * 7),
+		IssuerHash:   crypto.SHA256,
+	}
+	subjectDER, err := asn1.Marshal(pkix.Name{CommonName: "fake-responder.example"}.ToRDNSequence())
+	if err != nil {
+		return nil, err
+	}
+	responderCert := x509.Certificate{
+		// This is the only field that ocsp.CreateResponse reads.
+		RawSubject: subjectDER,
+	}
+	resp, err := ocsp.CreateResponse(cert, &responderCert, template, this.key)
+	if err != nil {
+		return nil, err
+	}
+	_, err = ocsp.ParseResponseForCert(resp, cert, cert)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/cmd/gateway_server/server.go
+++ b/cmd/gateway_server/server.go
@@ -74,7 +74,7 @@ func (s *gatewayServer) GenerateSXG(ctx context.Context, request *pb.SXGRequest)
 	}
 
 	// Note: do not initialize certCache, we just want it to hold the certs for now.
-	certCache := certcache.New(certs, nil, []string{""}, "", "", "");
+	certCache := certcache.New(certs, nil, []string{""}, "", "", "", false);
 
 	privateKey, err := util.ParsePrivateKey(request.PrivateKey)
 	if err != nil {

--- a/cmd/gateway_server/server.go
+++ b/cmd/gateway_server/server.go
@@ -74,7 +74,7 @@ func (s *gatewayServer) GenerateSXG(ctx context.Context, request *pb.SXGRequest)
 	}
 
 	// Note: do not initialize certCache, we just want it to hold the certs for now.
-	certCache := certcache.New(certs, nil, []string{""}, "", "", "", false);
+	certCache := certcache.New(certs, nil, []string{""}, "", "", "", nil);
 
 	privateKey, err := util.ParsePrivateKey(request.PrivateKey)
 	if err != nil {

--- a/packager/certcache/certcache.go
+++ b/packager/certcache/certcache.go
@@ -69,9 +69,7 @@ const maxOCSPTries = 10
 // TODO(banaag): make 2 days renewal grace period configurable in toml.
 const certRenewalInterval = 8 * 24 * time.Hour
 
-// Sentinel value used to communicate that a returned OCSP was fake, and the caller should not attempt to parse it.
-// No, I'm not proud.
-var fakeOCSP = []byte("fake ocsp response")
+type OCSPResponder func(*x509.Certificate) ([]byte, error)
 
 type CertHandler interface {
 	GetLatestCert() *x509.Certificate
@@ -94,7 +92,10 @@ type CertCache struct {
 	ocspFile     Updateable
 	ocspFilePath string
 	client       http.Client
-	developmentMode bool
+	// Given a certificate, returns a current OCSP response for the cert;
+	// this is a fallback, called when in development mode and there is no
+	// OCSP URL.
+	generateOCSPResponse OCSPResponder
 	// Domains to validate
 	Domains     []string
 	CertFile    string
@@ -119,7 +120,7 @@ type CertCache struct {
 // An alternative pattern would be to create an IsInitialized() bool or similarly named function that verifies all of the required fields have
 // been set. Then callers can just set fields in the struct by name and assert IsInitialized before doing anything with it.
 func New(certs []*x509.Certificate, certFetcher *certfetcher.CertFetcher, domains []string,
-	certFile string, newCertFile string, ocspCache string, developmentMode bool) *CertCache {
+	certFile string, newCertFile string, ocspCache string, generateOCSPResponse OCSPResponder) *CertCache {
 	certName := ""
 	if len(certs) > 0 && certs[0] != nil {
 		certName = util.CertName(certs[0])
@@ -140,8 +141,8 @@ func New(certs []*x509.Certificate, certFetcher *certfetcher.CertFetcher, domain
 		//    you'd have one request, in the backend, and updating them all.
 		ocspFile:     &Chained{first: &InMemory{}, second: &LocalFile{path: ocspCache}},
 		ocspFilePath: ocspCache,
+		generateOCSPResponse: generateOCSPResponse,
 		client:       http.Client{Timeout: 60 * time.Second},
-		developmentMode: developmentMode,
 		extractOCSPServer: func(cert *x509.Certificate) (string, error) {
 			if cert == nil || len(cert.OCSPServer) < 1 {
 				return "", errors.New("Cert missing OCSPServer.")
@@ -269,20 +270,15 @@ func (this *CertCache) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 			util.NewHTTPError(http.StatusInternalServerError, "Error reading OCSP: ", err).LogAndRespond(resp)
 			return
 		}
-		var expiry int
-		if bytes.Equal(ocsp, fakeOCSP) {
-			expiry = int(time.Now().Add(3*24*time.Hour).Unix())
-		} else {
-			midpoint, err := this.ocspMidpoint(ocsp, this.findIssuer())
-			if err != nil {
-				util.NewHTTPError(http.StatusInternalServerError, "Error computing OCSP midpoint: ", err).LogAndRespond(resp)
-				return
-			}
-			// int is large enough to represent 24855 days in seconds.
-			expiry = int(midpoint.Sub(time.Now()).Seconds())
-			if expiry < 0 {
-				expiry = 0
-			}
+		midpoint, err := this.ocspMidpoint(ocsp, this.findIssuer())
+		if err != nil {
+			util.NewHTTPError(http.StatusInternalServerError, "Error computing OCSP midpoint: ", err).LogAndRespond(resp)
+			return
+		}
+		// int is large enough to represent 24855 days in seconds.
+		expiry := int(midpoint.Sub(time.Now()).Seconds())
+		if expiry < 0 {
+			expiry = 0
 		}
 		resp.Header().Set("Cache-Control", "public, max-age="+strconv.Itoa(expiry))
 		resp.Header().Set("X-Content-Type-Options", "nosniff")
@@ -324,9 +320,6 @@ func (this *CertCache) isHealthy(ocspResp []byte) error {
 	issuer := this.findIssuer()
 	if issuer == nil {
 		return errors.New("Cannot find issuer certificate in CertFile.")
-	}
-	if bytes.Equal(ocspResp, fakeOCSP) {
-		return nil
 	}
 	resp, err := ocsp.ParseResponseForCert(ocspResp, this.getCert(), issuer)
 	if err != nil {
@@ -467,9 +460,6 @@ func (this *CertCache) shouldUpdateOCSP(ocsp []byte) bool {
 		// This is a permanent error; do not attempt OCSP update.
 		return false
 	}
-	if bytes.Equal(ocsp, fakeOCSP) {
-		return false
-	}
 	// Compute the midpoint per sleevi #3 (see above).
 	midpoint, err := this.ocspMidpoint(ocsp, issuer)
 	if err != nil {
@@ -554,12 +544,17 @@ func (this *CertCache) fetchOCSP(orig []byte, certs []*x509.Certificate, ocspUpd
 
 	ocspServer, err := this.extractOCSPServer(certs[0])
 	if err != nil {
-		if this.developmentMode {
-			log.Println("Cert lacks OCSP URL; using fake OCSP in development mode.")
-			return fakeOCSP
+		if this.generateOCSPResponse == nil {
+			log.Println("Error extracting OCSP server:", err)
+			return orig
 		}
-		log.Println("Error extracting OCSP server:", err)
-		return orig
+		log.Println("Cert lacks OCSP URL; using fake OCSP in development mode.")
+		resp, err := this.generateOCSPResponse(certs[0])
+		if err != nil {
+			log.Println("error generating fake OCSP response:", err)
+			return orig
+		}
+		return resp
 	}
 
 	// Conform to the Lightweight OCSP Profile, by preferring GET over POST
@@ -842,7 +837,7 @@ func (this *CertCache) reloadCertIfExpired() {
 // Creates cert cache by loading certs and keys from disk, doing validation
 // and populating the cert cache with current set of certificate related information.
 // If development mode is true, prints a warning for certs that can't sign HTTP exchanges.
-func PopulateCertCache(config *util.Config, key crypto.PrivateKey,
+func PopulateCertCache(config *util.Config, key crypto.PrivateKey, generateOCSPResponse OCSPResponder,
 	developmentMode bool, autoRenewCert bool) (*CertCache, error) {
 
 	if config.CertFile == "" {
@@ -855,7 +850,7 @@ func PopulateCertCache(config *util.Config, key crypto.PrivateKey,
 
 	certs, err := certloader.LoadCertsFromFile(config, developmentMode)
 	if err != nil {
-		log.Println(errors.Wrap(err, "Can't load cert file."))
+		log.Println(errors.Wrap(err, "Can't load cert file"))
 		certs = nil
 	}
 	domain := ""
@@ -872,7 +867,7 @@ func PopulateCertCache(config *util.Config, key crypto.PrivateKey,
 	if err != nil {
 		return nil, errors.Wrap(err, "creating cert fetcher from config.")
 	}
-	certCache := New(certs, certFetcher, []string{domain}, config.CertFile, config.NewCertFile, config.OCSPCache, developmentMode)
+	certCache := New(certs, certFetcher, []string{domain}, config.CertFile, config.NewCertFile, config.OCSPCache, generateOCSPResponse)
 
 	return certCache, nil
 }

--- a/packager/certcache/certcache.go
+++ b/packager/certcache/certcache.go
@@ -872,7 +872,7 @@ func PopulateCertCache(config *util.Config, key crypto.PrivateKey,
 	if err != nil {
 		return nil, errors.Wrap(err, "creating cert fetcher from config.")
 	}
-	certCache := New(certs, certFetcher, []string{domain}, config.CertFile, config.NewCertFile, config.OCSPCache)
+	certCache := New(certs, certFetcher, []string{domain}, config.CertFile, config.NewCertFile, config.OCSPCache, developmentMode)
 
 	return certCache, nil
 }

--- a/packager/certcache/certcache_test.go
+++ b/packager/certcache/certcache_test.go
@@ -81,7 +81,7 @@ func (this *CertCacheSuite) New() (*CertCache, error) {
 	// TODO(banaag): Consider adding a test with certfetcher set.
 	//  For now, this tests certcache without worrying about certfetcher.
 	certCache := New(pkgt.B3Certs, nil, []string{"example.com"}, "cert.crt", "newcert.crt",
-		filepath.Join(this.tempDir, "ocsp"), false)
+		filepath.Join(this.tempDir, "ocsp"), nil)
 	certCache.extractOCSPServer = func(*x509.Certificate) (string, error) {
 		return this.ocspServer.URL, nil
 	}
@@ -357,6 +357,7 @@ func (this *CertCacheSuite) TestPopulateCertCache() {
 			}},
 		},
 		pkgt.B3Key,
+		nil,
 		true,
 		false)
 	this.Require().NoError(err)

--- a/packager/certcache/certcache_test.go
+++ b/packager/certcache/certcache_test.go
@@ -81,7 +81,7 @@ func (this *CertCacheSuite) New() (*CertCache, error) {
 	// TODO(banaag): Consider adding a test with certfetcher set.
 	//  For now, this tests certcache without worrying about certfetcher.
 	certCache := New(pkgt.B3Certs, nil, []string{"example.com"}, "cert.crt", "newcert.crt",
-		filepath.Join(this.tempDir, "ocsp"))
+		filepath.Join(this.tempDir, "ocsp"), false)
 	certCache.extractOCSPServer = func(*x509.Certificate) (string, error) {
 		return this.ocspServer.URL, nil
 	}


### PR DESCRIPTION
If the cert doesn't have an AIA extension with an OCSP responder URL,
then the cache will just include a fake (invalid) OCSP response in its
cert-chain+cbor. This is sufficient for displaying the SXG in Chrome
with --ignore-certificate-errors-spki-list.

Fixes #352.