### PR TITLE
multi domain cert/key support

### DIFF
--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -90,6 +90,12 @@ ForwardedRequestHeaders = []
     # certificate must cover this domain.
     Domain = "amppackageexample.com"
 
+    # The CertFile used, defaulting to the top level defined CertFile if not provided.
+    # CertFile = "./pems/amppackageexample.com/cert.pem"
+    
+    # The KeyFile used, defaulting to the top level defined KeyFile if not provided.
+    # KeyFile = "./pems/amppackageexample.com/privkey.pem"
+
     # A full-match regexp on the path (not including the ?query). Defaults to
     # ".*".
     #

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -84,17 +84,23 @@ func main() {
 
   for _, urlSet := range config.URLSet {
     domain := urlSet.Sign.Domain
-    // Check for CertFile and/or KeyFile for usage, otherwise use the one
+    // Check for Sign level CertFile and/or KeyFile, otherwise use the one
     // defined at the top level.
     signCert := urlSet.Sign.CertFile
     if signCert != "" {
+      fmt.Println("Using Cert: ", signCert, "for domain: ", domain)
       certPem = readFile(signCert)
-      certs := parseCertificates(certPem, signCert)
+      certs = parseCertificates(certPem, signCert)
       canSignHttpExchanges(certs[0], time.Now())
+    } else {
+      fmt.Println("Using Cert: ", config.CertFile, "for domain: ", domain)
     }
     if urlSet.Sign.KeyFile != "" {
+      fmt.Println("Using key: ", urlSet.Sign.KeyFile, "for domain: ", domain)
       keyPem = readFile(urlSet.Sign.KeyFile)
       key = parsePrivateKey(keyPem, urlSet.Sign.KeyFile)
+    } else {
+      fmt.Println("Using Key: ", config.KeyFile, "for domain: ", domain)
     }
     if err := util.CertificateMatches(certs[0], key, domain); err != nil {
       die(errors.Wrapf(err, "checking %s", config.CertFile))

--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -18,6 +18,8 @@
 package main
 
 import (
+  "crypto"
+  "crypto/x509"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -73,42 +75,31 @@ func main() {
 		die(errors.Wrapf(err, "parsing config at %s", *flagConfig))
 	}
 
-	// TODO(twifkak): Document what cert/key storage formats this accepts.
-	certPem, err := ioutil.ReadFile(config.CertFile)
-	if err != nil {
-		die(errors.Wrapf(err, "reading %s", config.CertFile))
-	}
-	keyPem, err := ioutil.ReadFile(config.KeyFile)
-	if err != nil {
-		die(errors.Wrapf(err, "reading %s", config.KeyFile))
-	}
+  // TODO(twifkak): Document what cert/key storage formats this accepts.
+  certPem := readFile(config.CertFile)
+  keyPem := readFile(config.KeyFile)
+  certs := parseCertificates(certPem, config.CertFile)
+  canSignHttpExchanges(certs[0], time.Now())
+  key := parsePrivateKey(keyPem, config.KeyFile)
 
-	certs, err := signedexchange.ParseCertificates(certPem)
-	if err != nil {
-		die(errors.Wrapf(err, "parsing %s", config.CertFile))
-	}
-	if certs == nil || len(certs) == 0 {
-		die(fmt.Sprintf("no cert found in %s", config.CertFile))
-	}
-	if err := util.CanSignHttpExchanges(certs[0], time.Now()); err != nil {
-		if *flagDevelopment || *flagInvalidCert {
-			log.Println("WARNING:", err)
-		} else {
-			die(err)
-		}
-	}
-
-	key, err := util.ParsePrivateKey(keyPem)
-	if err != nil {
-		die(errors.Wrapf(err, "parsing %s", config.KeyFile))
-	}
-
-	for _, urlSet := range config.URLSet {
-		domain := urlSet.Sign.Domain
-		if err := util.CertificateMatches(certs[0], key, domain); err != nil {
-			die(errors.Wrapf(err, "checking %s", config.CertFile))
-		}
-	}
+  for _, urlSet := range config.URLSet {
+    domain := urlSet.Sign.Domain
+    // Check for CertFile and/or KeyFile for usage, otherwise use the one
+    // defined at the top level.
+    signCert := urlSet.Sign.CertFile
+    if signCert != "" {
+      certPem = readFile(signCert)
+      certs := parseCertificates(certPem, signCert)
+      canSignHttpExchanges(certs[0], time.Now())
+    }
+    if urlSet.Sign.KeyFile != "" {
+      keyPem = readFile(urlSet.Sign.KeyFile)
+      key = parsePrivateKey(keyPem, urlSet.Sign.KeyFile)
+    }
+    if err := util.CertificateMatches(certs[0], key, domain); err != nil {
+      die(errors.Wrapf(err, "checking %s", config.CertFile))
+    }
+  }
 
 	validityMap, err := validitymap.New()
 	if err != nil {
@@ -179,4 +170,41 @@ func main() {
 	} else {
 		log.Fatal(server.ListenAndServe())
 	}
+}
+
+func canSignHttpExchanges(cert *x509.Certificate, now time.Time) {
+  if err := util.CanSignHttpExchanges(cert, time.Now()); err != nil {
+		if *flagDevelopment || *flagInvalidCert {
+			log.Println("WARNING:", err)
+		} else {
+			die(err)
+		}
+	}
+}
+
+func readFile(fileName string) []byte {
+  file, err := ioutil.ReadFile(fileName)
+  if err != nil {
+    die(errors.Wrapf(err, "reading %s", fileName))
+  }
+  return file
+}
+
+func parseCertificates(certPem []byte, certFileName string) []*x509.Certificate {
+  certs, err := signedexchange.ParseCertificates(certPem)
+  if err != nil {
+    die(errors.Wrapf(err, "parsing %s", certFileName))
+  }
+  if certs == nil || len(certs) == 0 {
+    die(fmt.Sprintf("no cert found in %s", certFileName))
+  }
+  return certs
+}
+
+func parsePrivateKey(keyPem []byte, keyFileName string) crypto.PrivateKey {
+  key, err := util.ParsePrivateKey(keyPem)
+  if err != nil {
+    die(errors.Wrapf(err, "parsing %s", keyFileName))
+  }
+  return key
 }

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -157,10 +157,10 @@ func (this *SignerSuite) SetupTest() {
 }
 
 func (this *SignerSuite) TestSimple() {
-	urlSets := []util.URLSet{{
-		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
-	}}
+ urlSets := []util.URLSet{{
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 2000,  stringPtr("/amp/.*"), []string{}, stringPtr(""), boolPtr(true), []string{"https"}},
+  }}  
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath)+
 			"&sign="+url.QueryEscape(this.httpSignURL()+fakePath))
@@ -198,10 +198,10 @@ func (this *SignerSuite) TestSimple() {
 }
 
 func (this *SignerSuite) TestFetchSignWithForwardedRequestHeaders() {
-	urlSets := []util.URLSet{{
-		Sign:  &util.URLPattern{[]string{"https"}, "", this.certSubjectCN(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
-	}}
+  urlSets := []util.URLSet{{
+    Sign:  &util.URLPattern{"", "", this.certSubjectCN(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 200,  stringPtr("/amp/.*"), []string{}, stringPtr(""), boolPtr(true), []string{"https"}},
+  }}  
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		// Host and X-Foo headers are forwarded with forwardedRequestHeaders
 		this.Assert().Equal("www.example.com", req.Host)
@@ -246,10 +246,10 @@ func (this *SignerSuite) TestFetchSignWithForwardedRequestHeaders() {
 }
 
 func (this *SignerSuite) TestEscapeQueryParamsInFetchAndSign() {
-	urlSets := []util.URLSet{{
-		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, nil},
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, boolPtr(true)},
-	}}
+  urlSets := []util.URLSet{{
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(".*"), nil, []string{"https"}},
+    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 200,  stringPtr("/amp/.*"), []string{}, stringPtr(".*"), boolPtr(true), []string{"https"}},
+  }}
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath+"?<hi>")+
 			"&sign="+url.QueryEscape(this.httpSignURL()+fakePath+"?<hi>"))
@@ -263,7 +263,7 @@ func (this *SignerSuite) TestEscapeQueryParamsInFetchAndSign() {
 
 func (this *SignerSuite) TestDisallowInvalidCharsSign() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?&sign="+url.QueryEscape(this.httpSignURL()+fakePath+"<hi>"))
@@ -272,7 +272,8 @@ func (this *SignerSuite) TestDisallowInvalidCharsSign() {
 
 func (this *SignerSuite) TestNoFetchParam() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
 
@@ -284,7 +285,7 @@ func (this *SignerSuite) TestNoFetchParam() {
 
 func (this *SignerSuite) TestSignAsPathParam() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	resp := this.get(this.T(), this.new(urlSets), `/priv/doc/`+this.httpsURL()+fakePath)
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -297,7 +298,7 @@ func (this *SignerSuite) TestSignAsPathParam() {
 
 func (this *SignerSuite) TestSignAsPathParamWithQuery() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(".*"), nil, []string{"https"}},
 	}}
 	resp := this.get(this.T(), this.new(urlSets), `/priv/doc/`+this.httpsURL()+fakePath+"?amp=1")
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -311,7 +312,7 @@ func (this *SignerSuite) TestSignAsPathParamWithQuery() {
 // Ensure that the server doesn't attempt to percent-decode the sign URL.
 func (this *SignerSuite) TestSignAsPathParamWithUnusualPctEncoding() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	resp := this.get(this.T(), this.new(urlSets), `/priv/doc/`+this.httpsURL()+fakePath+`%2A`)
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -324,7 +325,8 @@ func (this *SignerSuite) TestSignAsPathParamWithUnusualPctEncoding() {
 
 func (this *SignerSuite) TestPreservesContentType() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html;charset=utf-8;v=5")
 		resp.Write(fakeBody)
@@ -339,7 +341,8 @@ func (this *SignerSuite) TestPreservesContentType() {
 
 func (this *SignerSuite) TestRemovesLinkHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},    
+  }}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Link", "rel=preload;<http://1.2.3.4/>")
@@ -355,7 +358,8 @@ func (this *SignerSuite) TestRemovesLinkHeaders() {
 
 func (this *SignerSuite) TestRemovesStatefulHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Set-Cookie", "yum yum yum")
@@ -372,15 +376,17 @@ func (this *SignerSuite) TestRemovesStatefulHeaders() {
 func (this *SignerSuite) TestMutatesCspHeaders() {
 	urlSets := []util.URLSet{{
 		Sign: &util.URLPattern{
-			[]string{"https"},
-			"",
+      "",
+      "",
 			this.httpsHost(),
+      false,
+      "",
+			2000,
 			stringPtr("/amp/.*"),
 			[]string{},
 			stringPtr(""),
-			false,
-			2000,
-			nil}}}
+			nil,
+      []string{"https"}}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		// Expect base-uri and block-all-mixed-content to remain unmodified.
@@ -415,7 +421,8 @@ func (this *SignerSuite) TestMutatesCspHeaders() {
 
 func (this *SignerSuite) TestAddsLinkHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Write([]byte("<html amp><head><link rel=stylesheet href=foo><script src=bar>"))
@@ -430,7 +437,8 @@ func (this *SignerSuite) TestAddsLinkHeaders() {
 
 func (this *SignerSuite) TestEscapesLinkHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		// This shouldn't happen for valid AMP, and AMP Caches should
@@ -450,7 +458,8 @@ func (this *SignerSuite) TestEscapesLinkHeaders() {
 
 func (this *SignerSuite) TestRemovesHopByHopHeaders() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Connection", "PROXY-AUTHENTICATE, Server")
@@ -473,7 +482,7 @@ func (this *SignerSuite) TestRemovesHopByHopHeaders() {
 
 func (this *SignerSuite) TestErrorNoCache() {
 	urlSets := []util.URLSet{{
-		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
+    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), boolPtr(true), []string{"http"}},
 	}}
 	// Missing sign param generates an error.
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath))
@@ -483,7 +492,7 @@ func (this *SignerSuite) TestErrorNoCache() {
 
 func (this *SignerSuite) TestProxyUnsignedIfRedirect() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -500,7 +509,7 @@ func (this *SignerSuite) TestProxyUnsignedIfRedirect() {
 
 func (this *SignerSuite) TestProxyUnsignedIfNotModified() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -519,7 +528,7 @@ func (this *SignerSuite) TestProxyUnsignedIfNotModified() {
 
 func (this *SignerSuite) TestProxyUnsignedIfShouldntPackage() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	this.shouldPackage = false
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
@@ -531,7 +540,7 @@ func (this *SignerSuite) TestProxyUnsignedIfShouldntPackage() {
 
 func (this *SignerSuite) TestProxyUnsignedIfMissingAMPCacheTransformHeader() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"Accept": {"application/signed-exchange;v=" + accept.AcceptedSxgVersion}})
@@ -543,7 +552,7 @@ func (this *SignerSuite) TestProxyUnsignedIfMissingAMPCacheTransformHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedIfInvalidAMPCacheTransformHeader() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"Accept": {"application/signed-exchange;v=" + accept.AcceptedSxgVersion},
@@ -557,7 +566,7 @@ func (this *SignerSuite) TestProxyUnsignedIfInvalidAMPCacheTransformHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedIfMissingAcceptHeader() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"AMP-Cache-Transform": {"google"}})
@@ -569,7 +578,7 @@ func (this *SignerSuite) TestProxyUnsignedIfMissingAcceptHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedNonCachable() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -585,7 +594,7 @@ func (this *SignerSuite) TestProxyUnsignedNonCachable() {
 
 func (this *SignerSuite) TestProxyUnsignedBadContentEncoding() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -601,7 +610,7 @@ func (this *SignerSuite) TestProxyUnsignedBadContentEncoding() {
 
 func (this *SignerSuite) TestProxyUnsignedErrOnStatefulHeader() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -618,7 +627,7 @@ func (this *SignerSuite) TestProxyUnsignedErrOnStatefulHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedOnVariants() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil},
+  Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -635,7 +644,7 @@ func (this *SignerSuite) TestProxyUnsignedOnVariants() {
 
 func (this *SignerSuite) TestProxyUnsignedOnVariants04() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -652,7 +661,8 @@ func (this *SignerSuite) TestProxyUnsignedOnVariants04() {
 
 func (this *SignerSuite) TestProxyUnsignedIfNotAMP() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	nonAMPBody := []byte("<html><body>They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)")
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -668,7 +678,8 @@ func (this *SignerSuite) TestProxyUnsignedIfNotAMP() {
 
 func (this *SignerSuite) TestProxyUnsignedIfWrongAMP() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+  }}
 	wrongAMPBody := []byte("<html amp4email><body>They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)")
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -684,7 +695,7 @@ func (this *SignerSuite) TestProxyUnsignedIfWrongAMP() {
 
 func (this *SignerSuite) TestProxyTransformError() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
 	}}
 
 	// Generate a request for non-existent transformer that will fail
@@ -704,7 +715,7 @@ func (this *SignerSuite) TestProxyTransformError() {
 
 func (this *SignerSuite) TestProxyHeadersUnaltered() {
 	urlSets := []util.URLSet{{
-		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},   
 	}}
 
 	// "Perform local transformations" is close to the last opportunity that a

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -157,10 +157,10 @@ func (this *SignerSuite) SetupTest() {
 }
 
 func (this *SignerSuite) TestSimple() {
- urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 2000,  stringPtr("/amp/.*"), []string{}, stringPtr(""), boolPtr(true), []string{"https"}},
-  }}  
+	urlSets := []util.URLSet{{
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true), "", ""},
+	}}
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath)+
 			"&sign="+url.QueryEscape(this.httpSignURL()+fakePath))
@@ -198,10 +198,10 @@ func (this *SignerSuite) TestSimple() {
 }
 
 func (this *SignerSuite) TestFetchSignWithForwardedRequestHeaders() {
-  urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.certSubjectCN(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 200,  stringPtr("/amp/.*"), []string{}, stringPtr(""), boolPtr(true), []string{"https"}},
-  }}  
+	urlSets := []util.URLSet{{
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.certSubjectCN(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true), "", ""},
+	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		// Host and X-Foo headers are forwarded with forwardedRequestHeaders
 		this.Assert().Equal("www.example.com", req.Host)
@@ -246,10 +246,10 @@ func (this *SignerSuite) TestFetchSignWithForwardedRequestHeaders() {
 }
 
 func (this *SignerSuite) TestEscapeQueryParamsInFetchAndSign() {
-  urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(".*"), nil, []string{"https"}},
-    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 200,  stringPtr("/amp/.*"), []string{}, stringPtr(".*"), boolPtr(true), []string{"https"}},
-  }}
+	urlSets := []util.URLSet{{
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, nil, "", ""},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, boolPtr(true), "", ""},
+	}}
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath+"?<hi>")+
 			"&sign="+url.QueryEscape(this.httpSignURL()+fakePath+"?<hi>"))
@@ -263,7 +263,7 @@ func (this *SignerSuite) TestEscapeQueryParamsInFetchAndSign() {
 
 func (this *SignerSuite) TestDisallowInvalidCharsSign() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	resp := this.get(this.T(), this.new(urlSets),
 		"/priv/doc?&sign="+url.QueryEscape(this.httpSignURL()+fakePath+"<hi>"))
@@ -272,8 +272,7 @@ func (this *SignerSuite) TestDisallowInvalidCharsSign() {
 
 func (this *SignerSuite) TestNoFetchParam() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
 
@@ -285,7 +284,7 @@ func (this *SignerSuite) TestNoFetchParam() {
 
 func (this *SignerSuite) TestSignAsPathParam() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	resp := this.get(this.T(), this.new(urlSets), `/priv/doc/`+this.httpsURL()+fakePath)
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -298,7 +297,7 @@ func (this *SignerSuite) TestSignAsPathParam() {
 
 func (this *SignerSuite) TestSignAsPathParamWithQuery() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(".*"), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(".*"), false, 2000, nil, "", ""},
 	}}
 	resp := this.get(this.T(), this.new(urlSets), `/priv/doc/`+this.httpsURL()+fakePath+"?amp=1")
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -312,7 +311,7 @@ func (this *SignerSuite) TestSignAsPathParamWithQuery() {
 // Ensure that the server doesn't attempt to percent-decode the sign URL.
 func (this *SignerSuite) TestSignAsPathParamWithUnusualPctEncoding() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	resp := this.get(this.T(), this.new(urlSets), `/priv/doc/`+this.httpsURL()+fakePath+`%2A`)
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
@@ -325,8 +324,7 @@ func (this *SignerSuite) TestSignAsPathParamWithUnusualPctEncoding() {
 
 func (this *SignerSuite) TestPreservesContentType() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html;charset=utf-8;v=5")
 		resp.Write(fakeBody)
@@ -341,8 +339,7 @@ func (this *SignerSuite) TestPreservesContentType() {
 
 func (this *SignerSuite) TestRemovesLinkHeaders() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},    
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Link", "rel=preload;<http://1.2.3.4/>")
@@ -358,8 +355,7 @@ func (this *SignerSuite) TestRemovesLinkHeaders() {
 
 func (this *SignerSuite) TestRemovesStatefulHeaders() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Set-Cookie", "yum yum yum")
@@ -376,17 +372,17 @@ func (this *SignerSuite) TestRemovesStatefulHeaders() {
 func (this *SignerSuite) TestMutatesCspHeaders() {
 	urlSets := []util.URLSet{{
 		Sign: &util.URLPattern{
-      "",
-      "",
+			[]string{"https"},
+			"",
 			this.httpsHost(),
-      false,
-      "",
-			2000,
 			stringPtr("/amp/.*"),
 			[]string{},
 			stringPtr(""),
+			false,
+			2000,
 			nil,
-      []string{"https"}}}}
+      "",
+      ""}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		// Expect base-uri and block-all-mixed-content to remain unmodified.
@@ -421,8 +417,7 @@ func (this *SignerSuite) TestMutatesCspHeaders() {
 
 func (this *SignerSuite) TestAddsLinkHeaders() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Write([]byte("<html amp><head><link rel=stylesheet href=foo><script src=bar>"))
@@ -437,8 +432,7 @@ func (this *SignerSuite) TestAddsLinkHeaders() {
 
 func (this *SignerSuite) TestEscapesLinkHeaders() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		// This shouldn't happen for valid AMP, and AMP Caches should
@@ -458,8 +452,7 @@ func (this *SignerSuite) TestEscapesLinkHeaders() {
 
 func (this *SignerSuite) TestRemovesHopByHopHeaders() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
 		resp.Header().Set("Connection", "PROXY-AUTHENTICATE, Server")
@@ -482,7 +475,7 @@ func (this *SignerSuite) TestRemovesHopByHopHeaders() {
 
 func (this *SignerSuite) TestErrorNoCache() {
 	urlSets := []util.URLSet{{
-    Fetch: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), boolPtr(true), []string{"http"}},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true), "", ""},
 	}}
 	// Missing sign param generates an error.
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath))
@@ -492,7 +485,7 @@ func (this *SignerSuite) TestErrorNoCache() {
 
 func (this *SignerSuite) TestProxyUnsignedIfRedirect() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -509,7 +502,7 @@ func (this *SignerSuite) TestProxyUnsignedIfRedirect() {
 
 func (this *SignerSuite) TestProxyUnsignedIfNotModified() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -528,7 +521,7 @@ func (this *SignerSuite) TestProxyUnsignedIfNotModified() {
 
 func (this *SignerSuite) TestProxyUnsignedIfShouldntPackage() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	this.shouldPackage = false
 	resp := this.get(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath))
@@ -540,7 +533,7 @@ func (this *SignerSuite) TestProxyUnsignedIfShouldntPackage() {
 
 func (this *SignerSuite) TestProxyUnsignedIfMissingAMPCacheTransformHeader() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"Accept": {"application/signed-exchange;v=" + accept.AcceptedSxgVersion}})
@@ -552,7 +545,7 @@ func (this *SignerSuite) TestProxyUnsignedIfMissingAMPCacheTransformHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedIfInvalidAMPCacheTransformHeader() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"Accept": {"application/signed-exchange;v=" + accept.AcceptedSxgVersion},
@@ -566,7 +559,7 @@ func (this *SignerSuite) TestProxyUnsignedIfInvalidAMPCacheTransformHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedIfMissingAcceptHeader() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	resp := pkgt.GetH(this.T(), this.new(urlSets), "/priv/doc?sign="+url.QueryEscape(this.httpsURL()+fakePath), http.Header{
 		"AMP-Cache-Transform": {"google"}})
@@ -578,7 +571,7 @@ func (this *SignerSuite) TestProxyUnsignedIfMissingAcceptHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedNonCachable() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -594,7 +587,7 @@ func (this *SignerSuite) TestProxyUnsignedNonCachable() {
 
 func (this *SignerSuite) TestProxyUnsignedBadContentEncoding() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -610,7 +603,7 @@ func (this *SignerSuite) TestProxyUnsignedBadContentEncoding() {
 
 func (this *SignerSuite) TestProxyUnsignedErrOnStatefulHeader() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil, "", ""},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -627,7 +620,7 @@ func (this *SignerSuite) TestProxyUnsignedErrOnStatefulHeader() {
 
 func (this *SignerSuite) TestProxyUnsignedOnVariants() {
 	urlSets := []util.URLSet{{
-  Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil, "", ""},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -644,7 +637,7 @@ func (this *SignerSuite) TestProxyUnsignedOnVariants() {
 
 func (this *SignerSuite) TestProxyUnsignedOnVariants04() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), true, 2000, nil, "", ""},
 	}}
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -661,8 +654,7 @@ func (this *SignerSuite) TestProxyUnsignedOnVariants04() {
 
 func (this *SignerSuite) TestProxyUnsignedIfNotAMP() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	nonAMPBody := []byte("<html><body>They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)")
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -678,8 +670,7 @@ func (this *SignerSuite) TestProxyUnsignedIfNotAMP() {
 
 func (this *SignerSuite) TestProxyUnsignedIfWrongAMP() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},
-  }}
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""}}}
 	wrongAMPBody := []byte("<html amp4email><body>They like to OPINE. Get it? (Is he fir real? Yew gotta be kidding me.)")
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {
 		resp.Header().Set("Content-Type", "text/html")
@@ -695,7 +686,7 @@ func (this *SignerSuite) TestProxyUnsignedIfWrongAMP() {
 
 func (this *SignerSuite) TestProxyTransformError() {
 	urlSets := []util.URLSet{{
-    Sign:  &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},  
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 
 	// Generate a request for non-existent transformer that will fail
@@ -715,7 +706,7 @@ func (this *SignerSuite) TestProxyTransformError() {
 
 func (this *SignerSuite) TestProxyHeadersUnaltered() {
 	urlSets := []util.URLSet{{
-    Sign: &util.URLPattern{"", "", this.httpHost(), false, "", 2000, stringPtr("/amp/.*"), []string{}, stringPtr(""), nil, []string{"https"}},   
+		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil, "", ""},
 	}}
 
 	// "Perform local transformations" is close to the last opportunity that a

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -39,15 +39,17 @@ type URLSet struct {
 }
 
 type URLPattern struct {
-	Scheme                 []string
-	DomainRE               string
-	Domain                 string
-	PathRE                 *string
-	PathExcludeRE          []string
-	QueryRE                *string
-	ErrorOnStatefulHeaders bool
-	MaxLength              int
-	SamePath               *bool
+  CertFile               string
+  DomainRE               string
+  Domain                 string
+  ErrorOnStatefulHeaders bool
+  KeyFile                string
+  MaxLength              int
+  PathRE                 *string
+  PathExcludeRE          []string
+  QueryRE                *string
+  SamePath               *bool
+  Scheme                 []string  
 }
 
 // TODO(twifkak): Extract default values into a function separate from the one

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -39,17 +39,17 @@ type URLSet struct {
 }
 
 type URLPattern struct {
+  Scheme                 []string
+	DomainRE               string
+	Domain                 string
+	PathRE                 *string
+	PathExcludeRE          []string
+	QueryRE                *string
+	ErrorOnStatefulHeaders bool
+	MaxLength              int
+	SamePath               *bool
   CertFile               string
-  DomainRE               string
-  Domain                 string
-  ErrorOnStatefulHeaders bool
   KeyFile                string
-  MaxLength              int
-  PathRE                 *string
-  PathExcludeRE          []string
-  QueryRE                *string
-  SamePath               *bool
-  Scheme                 []string  
 }
 
 // TODO(twifkak): Extract default values into a function separate from the one


### PR DESCRIPTION
Fixes: #363

Tested on alabiaga.dev and beebo.red domains with the following config:

    CertFile = './certs/beebo-red/certfile.pem'
    KeyFile = './certs/beebo-red/keyfile.pem'
    ...
    [[URLSet]]
      [URLSet.Sign]
         Domain = "beebo.red" # Uses top level defined cert and key

    [[URLSet]]
      [URLSet.Sign]
        Domain = "alabiaga.dev"
        CertFile = './certs/alabiaga-dev/certfile.pem' # Sign level defined CertFile
        KeyFile = './certs/alabiaga-dev/keyfile.pem' # Sign level defined KeyFile