### PR TITLE
make stop channel work properly for both maintainCerts and maintainOCSP

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -98,7 +98,7 @@ func main() {
 		die(errors.Wrap(err, "building cert cache"))
 	}
 
-	if err = certCache.Init(nil); err != nil {
+	if err = certCache.Init(); err != nil {
 		if *flagDevelopment {
 			fmt.Println("WARNING:", err)
 		} else {


### PR DESCRIPTION
Current implementation passes `stop` channel to both `maintainCerts` and `maintainOCSP` functions. It won't work as expected unless `stop` is buffered (e.g. `make(chan struct{}, 2)`) and the value is sent twice, which will result in a arcane parameter precondition of an exported function `CertCache.Init`.

This PR fixes that problem in another way. [PoC](https://play.golang.org/p/8MVG7ZdqDCq)