### PR TITLE
Add Forwarded headers to the fetch request.

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -177,6 +177,17 @@ func (this *Signer) fetchURL(fetch *url.URL, serveHTTPReq *http.Request) (*http.
 		}
 		req.Header.Set("Via", via)
 	}
+	if quotedHost, err := util.QuotedString(serveHTTPReq.Host); err == nil {
+		// TODO(twifkak): Extract host from upstream Forwarded header
+		// and concatenate. (Do not include any other parameters, as
+		// they may lead to over-signing.)
+		req.Header.Set("Forwarded", `host=` + quotedHost)
+		xfh := serveHTTPReq.Host
+		if oldXFH := serveHTTPReq.Header.Get("X-Forwarded-Host"); oldXFH != "" {
+			xfh = oldXFH + "," + xfh
+		}
+		req.Header.Set("X-Forwarded-Host", xfh)
+	}
 	// Set conditional headers that were included in ServeHTTP's Request.
 	for header := range util.ConditionalRequestHeaders {
 		if value := GetJoined(serveHTTPReq.Header, header); value != "" {

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -183,6 +183,8 @@ func (this *SignerSuite) TestSimple() {
 	this.Assert().Equal(fakePath, this.lastRequest.URL.String())
 	this.Assert().Equal(userAgent, this.lastRequest.Header.Get("User-Agent"))
 	this.Assert().Equal("1.1 amppkg", this.lastRequest.Header.Get("Via"))
+	this.Assert().Equal(`host="example.com"`, this.lastRequest.Header.Get("Forwarded"))
+	this.Assert().Equal("example.com", this.lastRequest.Header.Get("X-Forwarded-Host"))
 	this.Assert().Equal(http.StatusOK, resp.StatusCode, "incorrect status: %#v", resp)
 	this.Assert().Equal(fmt.Sprintf(`google;v="%d"`, transformer.SupportedVersions[0].Max), resp.Header.Get("AMP-Cache-Transform"))
 	this.Assert().Equal("nosniff", resp.Header.Get("X-Content-Type-Options"))

--- a/packager/util/http_test.go
+++ b/packager/util/http_test.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuotedString(t *testing.T) {
+	valueFrom := func(s string, _ error) string { return s }
+	errorFrom := func(_ string, err error) error { return err }
+
+	assert.EqualError(t, errorFrom(QuotedString("abc\ndef")), "contains non-printable char")
+	assert.Equal(t, `"abc"`, valueFrom(QuotedString("abc")))
+	assert.Equal(t, `"abc\"\\"`, valueFrom(QuotedString(`abc"\`)))
+}


### PR DESCRIPTION
To be cautious re: privacy/security, specify only host. Note that this
changes behavior for anybody who was previously including "Forwarded" or
"X-Forwarded-Host" in their ForwardedRequestHeaders in the config.

Fixes #260.