### PR TITLE
Make binary smaller by default, disabling DNS-01.

### DIFF
--- a/amppkg.example.toml
+++ b/amppkg.example.toml
@@ -255,6 +255,7 @@ ForwardedRequestHeaders = []
     # For the DNS challenge, go-acme/lego, there are certain environment variables that need to be set up which depends on
     # the DNS provider that you use to fulfill the DNS challenge.  See:
     # 	https://go-acme.github.io/lego/dns/
+    # To use this, build amppkg with `go build -tags dns01`; it is disabled by default because it bloats the binary.
     # DnsProvider = "gcloud"
 
   # This config will be used if 'autorenewcert' is turned on and 'development' is turned on.

--- a/packager/certfetcher/certfetcher.go
+++ b/packager/certfetcher/certfetcher.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-acme/lego/v3/challenge/http01"
 	"github.com/go-acme/lego/v3/challenge/tlsalpn01"
 	"github.com/go-acme/lego/v3/lego"
-	"github.com/go-acme/lego/v3/providers/dns"
 	"github.com/go-acme/lego/v3/providers/http/webroot"
 	"github.com/go-acme/lego/v3/registration"
 	"github.com/pkg/errors"
@@ -110,7 +109,7 @@ func New(email string, certSignRequest *x509.CertificateRequest, privateKey cryp
 	}
 
 	if dnsProvider != "" {
-		provider, err := dns.NewDNSChallengeProviderByName(dnsProvider)
+		provider, err := DNSProvider(dnsProvider)
 		if err != nil {
 			return nil, errors.Wrap(err, "Getting DNS01 challenge provider.")
 		}

--- a/packager/certfetcher/dns.go
+++ b/packager/certfetcher/dns.go
@@ -1,0 +1,12 @@
+// +build dns01
+
+package certfetcher
+
+import (
+	"github.com/go-acme/lego/v3/challenge"
+	"github.com/go-acme/lego/v3/providers/dns"
+)
+
+func DNSProvider(name string) (challenge.Provider, error) {
+	return dns.NewDNSChallengeProviderByName(name)
+}

--- a/packager/certfetcher/no_dns.go
+++ b/packager/certfetcher/no_dns.go
@@ -1,0 +1,12 @@
+// +build !dns01
+
+package certfetcher
+
+import (
+	"github.com/go-acme/lego/v3/challenge"
+	"github.com/pkg/errors"
+)
+
+func DNSProvider(name string) (challenge.Provider, error) {
+	return nil, errors.New("amppkg was built without DNS-01 support; please rebuild with `-tags dns01`")
+}


### PR DESCRIPTION
Reduce the size of the amppkg binary from 45M to 17M, by removing the
dependency on the rarely-needed DNS-01 libraries, unless
`go build -tags dns01` is specified.

Addresses #355.