### PR TITLE
Replace `csp-collector.appspot.com` with `csp.withgoogle.com`

### DIFF
--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -247,8 +247,7 @@ func MutateFetchedContentSecurityPolicy(fetched string) string {
 	// Add missing directives or replace the ones that were removed in some cases
 	newCsp.WriteString(
 		"default-src * blob: data:;" +
-			"report-uri https://csp.withgoogle.com/csp/amp " +
-			"https://csp-collector.appspot.com/csp/amp;" +
+			"report-uri https://csp.withgoogle.com/csp/amp;" +
 			"script-src blob: https://cdn.ampproject.org/rtv/ " +
 			"https://cdn.ampproject.org/v0.js " +
 			"https://cdn.ampproject.org/v0/ " +

--- a/packager/signer/signer.go
+++ b/packager/signer/signer.go
@@ -247,7 +247,8 @@ func MutateFetchedContentSecurityPolicy(fetched string) string {
 	// Add missing directives or replace the ones that were removed in some cases
 	newCsp.WriteString(
 		"default-src * blob: data:;" +
-			"report-uri https://csp-collector.appspot.com/csp/amp;" +
+			"report-uri https://csp.withgoogle.com/csp/amp " +
+			"https://csp-collector.appspot.com/csp/amp;" +
 			"script-src blob: https://cdn.ampproject.org/rtv/ " +
 			"https://cdn.ampproject.org/v0.js " +
 			"https://cdn.ampproject.org/v0/ " +

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -455,7 +455,7 @@ func (this *SignerSuite) TestMutatesCspHeaders() {
 		"base-uri http://*.example.com;"+
 			"block-all-mixed-content;"+
 			"default-src * blob: data:;"+
-			"report-uri https://csp-collector.appspot.com/csp/amp;"+
+			"report-uri https://csp.withgoogle.com/csp/amp https://csp-collector.appspot.com/csp/amp;"+
 			"script-src blob: https://cdn.ampproject.org/rtv/ https://cdn.ampproject.org/v0.js https://cdn.ampproject.org/v0/ https://cdn.ampproject.org/viewer/;"+
 			"style-src 'unsafe-inline' https://cdn.materialdesignicons.com https://cloud.typography.com https://fast.fonts.net https://fonts.googleapis.com https://maxcdn.bootstrapcdn.com https://p.typekit.net https://pro.fontawesome.com https://use.fontawesome.com https://use.typekit.net;"+
 			"object-src 'none'",

--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -455,7 +455,7 @@ func (this *SignerSuite) TestMutatesCspHeaders() {
 		"base-uri http://*.example.com;"+
 			"block-all-mixed-content;"+
 			"default-src * blob: data:;"+
-			"report-uri https://csp.withgoogle.com/csp/amp https://csp-collector.appspot.com/csp/amp;"+
+			"report-uri https://csp.withgoogle.com/csp/amp;"+
 			"script-src blob: https://cdn.ampproject.org/rtv/ https://cdn.ampproject.org/v0.js https://cdn.ampproject.org/v0/ https://cdn.ampproject.org/viewer/;"+
 			"style-src 'unsafe-inline' https://cdn.materialdesignicons.com https://cloud.typography.com https://fast.fonts.net https://fonts.googleapis.com https://maxcdn.bootstrapcdn.com https://p.typekit.net https://pro.fontawesome.com https://use.fontawesome.com https://use.typekit.net;"+
 			"object-src 'none'",


### PR DESCRIPTION
The URI end-point for the CSP Collector used by AMP was changed recently.

This PR adds the new URI as a valid option for SxG.