### PR TITLE
Fix crash on missing fetch param.

### DIFF
--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -309,6 +309,26 @@ func (this *SignerSuite) TestEscapeQueryParamsInFetchAndSign() {
 	this.Assert().Equal(this.httpSignURL()+fakePath+"?%3Chi%3E", exchange.RequestURI)
 }
 
+func (this *SignerSuite) TestMissingFetchParam() {
+	urlSets := []util.URLSet{{
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
+	}}
+	resp := this.get(this.T(), this.new(urlSets),
+		"/priv/doc?sign="+url.QueryEscape(this.httpSignURL()+fakePath))
+	this.Assert().Equal(http.StatusBadRequest, resp.StatusCode, "incorrect status: %#v", resp)
+}
+
+func (this *SignerSuite) TestMissingSignParam() {
+	urlSets := []util.URLSet{{
+		Sign:  &util.URLPattern{[]string{"https"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},
+		Fetch: &util.URLPattern{[]string{"http"}, "", this.httpHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, boolPtr(true)},
+	}}
+	resp := this.get(this.T(), this.new(urlSets),
+		"/priv/doc?fetch="+url.QueryEscape(this.httpURL()+fakePath))
+	this.Assert().Equal(http.StatusBadRequest, resp.StatusCode, "incorrect status: %#v", resp)
+}
+
 func (this *SignerSuite) TestDisallowInvalidCharsSign() {
 	urlSets := []util.URLSet{{
 		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil},

--- a/packager/signer/validation.go
+++ b/packager/signer/validation.go
@@ -109,6 +109,9 @@ func fetchURLMatches(url *url.URL, pattern *util.URLPattern) error {
 			return errors.New("If URLSet.Fetch is unspecified, then so should ?fetch= be.")
 		}
 	}
+	if url == nil {
+		return errors.New("?fetch= is unspecified")
+	}
 	// The fetch block may specify which schemes are allowed.
 	if !schemeMatches(url.Scheme, pattern.Scheme) {
 		return errors.New("Scheme doesn't match")


### PR DESCRIPTION
If fetch param is required by config but missing from the request,
respond with a 400 instead of panicking. Add tests for that and missing
sign param.

Fixes #405.