### PR TITLE
Refactor serveSignedExchange method.

### DIFF
--- a/packager/signer/signer_test.go
+++ b/packager/signer/signer_test.go
@@ -1041,7 +1041,7 @@ func (this *SignerSuite) TestIfCappedDontSignAndProxyFullDocument() {
 		Sign: &util.URLPattern{[]string{"https"}, "", this.httpsHost(), stringPtr("/amp/.*"), []string{}, stringPtr(""), false, 2000, nil}}}
 
 	const uncappedTailLength = 100
-	veryLongString := strings.Repeat("a", maxBodyLength+uncappedTailLength)
+	veryLongString := strings.Repeat("a", maxSignableBodyLength+uncappedTailLength)
 	var customFakeBody = []byte("<html amp><body>" + veryLongString)
 
 	this.fakeHandler = func(resp http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
The first few commands of serveSignedExchange method consume the fetchResp body and are somewhat tricky. The method first consumes all characters up to maxBodyLength limit. If the limit is hit, it proxies full body and exits. If the limit is not hit, it means that the body has been consumed fully and can be signed.

The subsequent calls to `proxy` rely on the background above. Specifically to call `proxy` correctly an engineer needs to remember that fetchResp.Body has already been consumed, and therefore it cannot be re-read. An engineer maintaining the serveSignedExchange method would need that knowledge throughout the whole method, which is somewhat long. There's even a comment to highlight that:

// After this, fetchResp.Body is consumed, and attempts to read or proxy it will result in an empty body.

The new serveSignedExchange_ConsumeCapCompliantFetchResp method encapsulates the logic above: it makes sure the fetch body was read, and takes care of potential io errors and potential hitting of maxBodyLength limit. serveSignedExchange_ConsumeCapCompliantFetchResp returns a `success` bool to notify serveSignedExchange if it's ok to continue signing, which, given with method name, seems straightforward, and makes understanding serveSignedExchange method easier.

Another, similar benefit: the whole capping notion gets hidden into the extracted method, and such structure emphasizes that the part of serveSignedExchange that follows the call to the extracted method works on a non-capped, full body, which is also below the expected limit. It also emphasizes that the body has been fully consumed, so `proxy` doesn't need to read anything else to proxy the full body.