### PR TITLE
Tell Travis to use -mod=readonly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 # https://docs.travis-ci.com/user/languages/go/
 language: go
 
-jobs:
-  include:
-    # Ask gimme to choose latest stable minor release of Go 1.10.
-    # https://github.com/travis-ci/gimme
-    - go: 1.10.x
-      env: GOFLAGS=-d
-    - go: 1.11.x
-      env: GO111MODULE=on
-    - go: 1.12.x
-      env: GO111MODULE=on
-    - go: 1.13.x
-    - go: 1.14.x
+# Use ".x" to ask gimme to choose latest stable minor version of each Go
+# release: https://github.com/travis-ci/gimme
+go:
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - 1.14.x
+
+env:
+  # Necessary for Go 1.11 and 1.12, so they'll respect the version constraints
+  # in go.mod.
+  - GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 # https://docs.travis-ci.com/user/languages/go/
 language: go
 
-# Ask gimme to choose latest stable minor release of Go 1.10.
-# https://github.com/travis-ci/gimme
-go: 
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
-  - 1.13.x
-  - 1.14.x
+jobs:
+  include:
+    # Ask gimme to choose latest stable minor release of Go 1.10.
+    # https://github.com/travis-ci/gimme
+    - go: 1.10.x
+      env: GOFLAGS=-d
+    - go: 1.11.x
+      env: GO111MODULE=on
+    - go: 1.12.x
+      env: GO111MODULE=on
+    - go: 1.13.x
+    - go: 1.14.x


### PR DESCRIPTION
This allows it to be tested with the exact version of the dependencies
specified in go.mod, and not the newest version of each such dep.

The latest version of stretchr/testify appears to be incompatible with
older versions of Go, per
https://travis-ci.org/github/ampproject/amppackager/builds/710522601.