### PR TITLE
Travis: GO111MODULES=on, disable Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 # https://docs.travis-ci.com/user/languages/go/
 language: go
 
-# Ask gimme to choose latest stable minor release of Go 1.10.
-# https://github.com/travis-ci/gimme
-go: 
-  - 1.10.x
+# Use ".x" to ask gimme to choose latest stable minor version of each Go
+# release: https://github.com/travis-ci/gimme
+go:
   - 1.11.x
   - 1.12.x
   - 1.13.x
   - 1.14.x
+
+env:
+  # Necessary for Go 1.11 and 1.12, so they'll respect the version constraints
+  # in go.mod.
+  - GO111MODULE=on


### PR DESCRIPTION
GO111MODULES=on allows it to be tested with the exact version of the
dependencies specified in go.mod for Go 1.11 and Go.12, and not the
newest version of each such dep.

This fixes a build failure caused by a commit to
github.com/stretchr/testify 3 days ago; see
https://travis-ci.org/github/ampproject/amppackager/builds/710522601.

Go 1.10 did not support modules in any form. It did support vendored
directories, but I'm not sure how to make Travis not run `go get` and
update them. So, let's finally stop testing on Go 1.10.
https://travis-ci.org/github/ampproject/amppackager/builds/710522601.