### PR TITLE
HtmlFormat sync with validator.proto

### DIFF
--- a/transformer/request/request.proto
+++ b/transformer/request/request.proto
@@ -36,6 +36,8 @@ message Request {
 
   // This should be kept in sync with HtmlFormat.Code in
   // github.com/ampproject/amphtml/validator/validator.proto.
+  // Deprecated fields, do not reuse:
+  // reserved 5;
   enum HtmlFormat {
     UNKNOWN_CODE = 0;  // Never used
     AMP = 1;


### PR DESCRIPTION
These two files were meant to be kept in sync but it appears the amppackager request.proto was missing ACTIONS. ACTIONS is now deprecated so adding in comment that 5 is reserved.

github.com/ampproject/amppackager/transformer/request/request.proto
github.com/ampproject/amphtml/validator/validator.proto