### PR TITLE
Add HMAC and KID fields to ACME config TOML for EAB integration.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.10.2 h1:VBodKICVPnwmDxstcW3biKcDSpFIfS/RELUXsZSBYK4=
@@ -250,15 +251,12 @@ github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod 
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
-github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
-github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0 h1:kRhiuYSXR3+uv2IbVbZhUxK5zVD/2pp3Gd2PpvPkpEo=

--- a/packager/certcache/certcache.go
+++ b/packager/certcache/certcache.go
@@ -717,6 +717,7 @@ func (this *CertCache) setCerts(certs []*x509.Certificate) {
 	this.certs = certs
 	this.certName = util.CertName(certs[0])
 
+	log.Printf("Writing cert %s to file %v", this.certName, this.CertFile)
 	err := certloader.WriteCertsToFile(this.certs, this.CertFile)
 	if err != nil {
 		log.Printf("Unable to write certs to file: %s", this.CertFile)

--- a/packager/certfetcher/certfetcher_test.go
+++ b/packager/certfetcher/certfetcher_test.go
@@ -89,8 +89,8 @@ func TestNewFetcher(t *testing.T) {
 		DNSNames: []string{"test.example.com"},
 	}
 
-	fetcher, err := New("test@test.com", &csr, privateKey, apiURL+"/dir",
-		5002, "", 0, "", false)
+	fetcher, err := New("test@test.com", "eab.kid", "eab.hmac", &csr,
+		privateKey, apiURL+"/dir", 5002, "", 0, "", false)
 	assert.Nil(t, err)
 	assert.NotNil(t, fetcher.legoClient)
 	assert.Equal(t, "test@test.com", fetcher.AcmeUser.Email)
@@ -120,8 +120,8 @@ func TestFetchCertSuccess(t *testing.T) {
 		DNSNames: []string{"test.example.com"},
 	}
 
-	fetcher, err := New("test@test.com", &csr, privateKey, apiURL+"/dir",
-		5002, "", 0, "", false)
+	fetcher, err := New("test@test.com", "eab.kid", "eab.hmac", &csr,
+		privateKey, apiURL+"/dir", 5002, "", 0, "", false)
 	assert.Nil(t, err)
 	assert.NotNil(t, fetcher)
 
@@ -151,8 +151,8 @@ func TestFetchCertFail(t *testing.T) {
 		DNSNames: []string{"test.example.com"},
 	}
 
-	fetcher, err := New("test@test.com", &csr, privateKey, apiURL+"/dir",
-		5002, "", 0, "", false)
+	fetcher, err := New("test@test.com", "eab.kid", "eab.hmac", &csr,
+		privateKey, apiURL+"/dir", 5002, "", 0, "", false)
 	assert.Nil(t, err)
 	assert.NotNil(t, fetcher)
 

--- a/packager/util/config.go
+++ b/packager/util/config.go
@@ -66,10 +66,17 @@ type ACMEConfig struct {
 }
 
 type ACMEServerConfig struct {
-	DiscoURL   string // ACME Directory Resource URL
-	AccountURL string // ACME Account URL. If non-empty, we
-	// will auto-renew cert via ACME.
-	EmailAddress string // Email address registered with ACME CA.
+	// ACME Directory Resource URL
+	AccountURL string
+	// ACME Account URL. If non-empty, we will auto-renew cert via ACME.
+	DiscoURL string
+	// Email address registered with ACME CA.
+	EmailAddress string
+	// Key Identifier from ACME CA. Used for External Account Binding.
+	EABKid string
+	// MAC Key from ACME CA. Used for External Account Binding. Should be in
+	// Base64 URL Encoding without padding format.
+	EABHmac string
 
 	// See: https://letsencrypt.org/docs/challenge-types/
 	// For non-wildcard domains, only one of HttpChallengePort, HttpWebRootDir or

--- a/packager/util/config_test.go
+++ b/packager/util/config_test.go
@@ -216,7 +216,9 @@ func TestOptionalACMEConfig(t *testing.T) {
 		  [ACMEConfig.Production]
 		    DiscoURL = "prod.disco.url"
 		    AccountURL = "prod.account.url"
-		    EmailAddress = "prodtest@test.com"
+			EmailAddress = "prodtest@test.com"
+			EABKid = "eab.kid"
+			EABHmac = "eab.hmac"
 		    HttpChallengePort = 777
 		    HttpWebRootDir = "web.root.dir"
 		    TlsChallengePort = 333
@@ -224,7 +226,9 @@ func TestOptionalACMEConfig(t *testing.T) {
 		  [ACMEConfig.Development]
 		    DiscoURL = "dev.disco.url"
 		    AccountURL = "dev.account.url"
-		    EmailAddress = "devtest@test.com"
+			EmailAddress = "devtest@test.com"
+			EABKid = "eab.kid"
+			EABHmac = "eab.hmac"
 		    HttpChallengePort = 888
 		    HttpWebRootDir = "web.root.dir"
 		    TlsChallengePort = 444
@@ -241,6 +245,8 @@ func TestOptionalACMEConfig(t *testing.T) {
 				DiscoURL:          "prod.disco.url",
 				AccountURL:        "prod.account.url",
 				EmailAddress:      "prodtest@test.com",
+				EABKid:            "eab.kid",
+				EABHmac:           "eab.hmac",
 				HttpChallengePort: 777,
 				HttpWebRootDir:    "web.root.dir",
 				TlsChallengePort:  333,
@@ -250,6 +256,8 @@ func TestOptionalACMEConfig(t *testing.T) {
 				DiscoURL:          "dev.disco.url",
 				AccountURL:        "dev.account.url",
 				EmailAddress:      "devtest@test.com",
+				EABKid:            "eab.kid",
+				EABHmac:           "eab.hmac",
 				HttpChallengePort: 888,
 				HttpWebRootDir:    "web.root.dir",
 				TlsChallengePort:  444,


### PR DESCRIPTION
Add HMAC and KID fields to ACME config TOML for EAB integration.