### PR TITLE
Update invalid cert testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,21 @@ Running `amppkg` with the `-invalidcert` flag will skip the check for
 `-development` flag.
 
 Chrome can be configured to allow these invalid certificates with the
-*Allow Signed HTTP Exchange certificates without extension* experiment:
-chrome://flags/#allow-sxg-certs-without-extension
+`--ignore-certificate-errors-spki-list` command line flag:
+
+```
+google-chrome --ignore-certificate-errors-spki-list=<hashes> --user-data-dir=<dir>
+```
+
+where `<hashes>` is a comma separated list of Base64-encoded SHA-256 SPKI
+Fingerprints and it is necessary to specify `--user-data-dir` with a valid
+directory `<dir>` when `--ignore-certificate-errors-spki-list` is used.
+
+As an example, the hash for a PEM certificate can be obtained with OpenSSL:
+
+```
+openssl x509 -pubkey -noout -in mycert.crt | openssl pkey -pubin -outform der | openssl sha256 -binary | openssl base64
+```
 
 #### Redundancy
 

--- a/README.md
+++ b/README.md
@@ -225,8 +225,9 @@ google-chrome --ignore-certificate-errors-spki-list=<hashes> --user-data-dir=<di
 ```
 
 where `<hashes>` is a comma separated list of Base64-encoded SHA-256 SPKI
-Fingerprints and it is necessary to specify `--user-data-dir` with a valid
-directory `<dir>` when `--ignore-certificate-errors-spki-list` is used.
+Fingerprints and it is necessary to specify `--user-data-dir` with a valid or
+creatable directory `<dir>` when `--ignore-certificate-errors-spki-list` is
+used.
 
 As an example, the hash for a PEM certificate can be obtained with OpenSSL:
 


### PR DESCRIPTION
Chrome feature flag AllowSignedHTTPExchangeCertsWithoutExtension was
removed in M89. https://bugs.chromium.org/p/chromium/issues/detail?id=862003

Fortunately, the ability to test SXGs using certificates lacking the
CanSignHttpExchanges(Draft) extension is still possible thanks to an
update to the --ignore-certificate-errors-spki-list command line flag.
https://bugs.chromium.org/p/chromium/issues/detail?id=956471

Update instructions to include an example of 1) how to launch Chrome
using this flag, and 2) how to generate a certificate public hash
suitable for use by this flag.

Additional information about flag:
https://chromium.googlesource.com/chromium/src/+/refs/tags/89.0.4389.130/services/network/public/cpp/network_switches.cc#24

<!--
Changes to files in `transformers/`, `internal/url/`, or `cmd/transform/` need
to be submitted in the Google repo first and then synced out to GitHub.
Non-Google contributors are encouraged to send PRs, but reviewers will patch
approved changes internally. Please read
https://github.com/ampproject/amppackager/wiki/Contributing#working-on-transformers
for details.
-->
