### PR TITLE
Enable pprof for debugging

### DIFF
--- a/cmd/amppkg/main.go
+++ b/cmd/amppkg/main.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/pkg/errors"

--- a/monitoring.md
+++ b/monitoring.md
@@ -46,6 +46,8 @@ requests handled by `amppackager`, and for the underlying gateway requests that
 `amppackager` sends to the AMP document server. Get all the metrics by `curl`ing
 the `/metrics` endpoint. 
 
+There is also [Go pprof](https://pkg.go.dev/net/http/pprof) available on `/debug/pprof`.
+
 ## Example: monitoring total requests count
 
 The example command below fetches all the available metrics. It then greps the report for `total_requests_by_code_and_url` metric. This metric counts the HTTP requests the `amppackager` server has processed since it's been up. 


### PR DESCRIPTION
In order to provide various runtime code profiling featuers, add the
standard Go pprof endpoint. This will allow investigations into
excessive CPU and memory use.

Signed-off-by: SuperQ <superq@gmail.com>