### PR TITLE
Reduce frequency of amphtml updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
   "postUpdateOptions": [
     "gomodUpdateImportPaths",
     "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["github.com/ampproject/amphtml"],
+      "extends": ["schedule:weekly"]
+    }
   ]
 }


### PR DESCRIPTION
Reduces updates of github.com/ampproject/amphtml to weekly, using
https://docs.renovatebot.com/configuration-options/#packagerules and
https://docs.renovatebot.com/presets-schedule/. The repo changes frequently,
but we depend only on the validator.proto Layout enum, which changes
infrequently.

<!--
Changes to files in `transformers/`, `internal/url/`, or `cmd/transform/` need
to be submitted in the Google repo first and then synced out to GitHub.
Non-Google contributors are encouraged to send PRs, but reviewers will patch
approved changes internally. Please read
https://github.com/ampproject/amppackager/wiki/Contributing#working-on-transformers
for details.
-->
