### PR TITLE
Limit WICG/webpackage updates to weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,10 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["github.com/ampproject/amphtml"],
+      "matchPackageNames": [
+        "github.com/WICG/webpackage",
+        "github.com/ampproject/amphtml"
+      ],
       "extends": ["schedule:weekly"]
     }
   ]


### PR DESCRIPTION
Most of its updates are outside the `go/signedexchange` directory, and hence
irrelevant to amppkg's use.

<!--
Changes to files in `transformers/`, `internal/url/`, or `cmd/transform/` need
to be submitted in the Google repo first and then synced out to GitHub.
Non-Google contributors are encouraged to send PRs, but reviewers will patch
approved changes internally. Please read
https://github.com/ampproject/amppackager/wiki/Contributing#working-on-transformers
for details.
-->
