### PR TITLE
Reduce renovate PRs by grouping.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "baseBranches": ["main"],
   "extends": [
-    "config:base"
+    "config:base",
+    "schedule:weekly"
   ],
   "postUpdateOptions": [
     "gomodUpdateImportPaths",
@@ -9,11 +10,8 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "github.com/WICG/webpackage",
-        "github.com/ampproject/amphtml"
-      ],
-      "extends": ["schedule:weekly"]
+      "matchLanguages": ["golang"],
+      "groupName": "golang dependencies"
     }
   ]
 }


### PR DESCRIPTION
Reduce regular schedule to weekly, and group all golang updates in one PR.

In a future update, we should consider setting `automerge: true` for
`matchUpdateTypes: ["patch"]`.

<!--
Changes to files in `transformers/`, `internal/url/`, or `cmd/transform/` need
to be submitted in the Google repo first and then synced out to GitHub.
Non-Google contributors are encouraged to send PRs, but reviewers will patch
approved changes internally. Please read
https://github.com/ampproject/amppackager/wiki/Contributing#working-on-transformers
for details.
-->
